### PR TITLE
Follow H3 prompt format for base and ref models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,15 @@ than that, and two of its sections were structurally missing from the output.
   because copying a signal and imitating one are different jobs. An off-spec value coming
   from an edited timeline is clamped rather than passed through into the prompt.
 
+- **The sentence after the marker is yours to write.** The guide's own retention lines name
+  actual features rather than a stock phrase — `fully_preserved - the Samoyed's thick white
+  fur, pointed ears, dark nose, and curved tail are retained`. Every reference has a
+  **retained** box for that: subject slots in the panel, timeline images, reference videos
+  and audio clips in the properties panel. Left empty, a sentence is generated from the
+  reference's kind, so the box overrides and never obliges. Subject slots and
+  subject-defining images carry two boxes, because they feed two different sections:
+  **describes** becomes the `<Subject N>` definition, **retained** the retention line.
+
 - **An image only gets a `<Picture N>` entry when it really is one.** The guide: "If an
   image is used only to define a character, scene, costume, or style, do not create a
   standalone picture entry. Instead, cite the image source inside the corresponding
@@ -42,16 +51,22 @@ than that, and two of its sections were structurally missing from the output.
   was prose. The two sections now follow the guide's shapes, and a subject's
   `(appears in [Shot 1], [Shot 3])` is read back off the shot text rather than assumed.
 
+  Both are written one entry per line, the way the guide lays them out. They are lists of
+  records rather than prose, and running a dozen of them together into a paragraph made it
+  genuinely hard to see where one label ended and the next began.
+
   ```
   0.1.5   subject_definitions: <Subject 1> is the character shown in <Picture 1>.
           retention_analysis: Keep the identity, face and clothing of <Subject 1>
                               consistent across every shot. [Shot 1] begins from <Picture 2>.
 
-  0.2.0   subject_definitions: <Subject 1> is a woman in a red coat, shown in <Picture 1>.
-                               <Picture 2> is the first frame of [Shot 1].
+  0.2.0   subject_definitions:
+          <Subject 1> is a woman in a red coat, shown in <Picture 1>.
+          <Picture 2> is the first frame of [Shot 1].
+
           retention_analysis:
-          <Subject 1> (appears in [Shot 1]): fully_preserved - the identity, face and
-            clothing of <Subject 1> are retained.
+          <Subject 1> (appears in [Shot 1]): fully_preserved - the collar shape and the
+            silver necklace are retained.
           <Picture 2> ([Shot 1] first frame): fully_preserved - the framing and
             composition of <Picture 2> are retained.
   ```
@@ -69,6 +84,25 @@ than that, and two of its sections were structurally missing from the output.
   `[Shot 1] she enters. The shot begins from <Picture 2>.` The phrase goes after the
   shot's own text, because a later shot opens `At 00:05.000, ` and a capitalised clause
   cannot continue out of that comma.
+
+- **The reference panel resizes, and the images grow with it.** The previews were locked to
+  52px inside a fixed 148px slot — too small to judge a reference by, and with no room for
+  a second text box. The panel now has the same drag strip the prompt and global-prompt
+  panels have, its height is remembered per node, and the previews row is the only part
+  that flexes, so every pixel gained goes to the image rather than to the text.
+
+- **`overall_soundscape`, `non_diegetic_music` and the new `summary` box sit beside the
+  global prompt, not on top of it.** The strip was absolutely positioned over the textarea,
+  which was shortened by a hard-coded `calc()` to compensate — so the two fought over the
+  same space and the strip sat on the box's own border. As a flex sibling the panel divides
+  itself, with no second copy of the height to keep in step.
+
+- **Analyze no longer assumes every slot is a character.** Its prompt said "describe the
+  character's physical appearance", which produced what you would expect when the image was
+  a coffee shop. It now asks about the slot's actual kind — a place, a garment, a pose —
+  and returns the description and the retained sentence together. A model that ignores the
+  two-line format still works: everything falls back to the description, and a note written
+  by hand is never overwritten.
 
 - **The chain node and the Director now share one reference loader.** The chain had grown
   its own copy that ignored the `ref_images` socket entirely and never fitted a keyframe to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,34 @@ than that, and two of its sections were structurally missing from the output.
   two-line format still works: everything falls back to the description, and a note written
   by hand is never overwritten.
 
+- **Speakers and dialogue.** The guide gives speakers stable `(Sx)` IDs "according to the
+  order of actual vocal events in the target video" and wraps their lines in
+  `<d>[Language] …</d>`. Neither existed here. A line that starts with a reference tag and
+  contains a colon is now dialogue — the same "only at the start of a line" rule the
+  `Audio:` / `Music:` lines already follow:
+
+  ```
+  @ref1 exclaims with light annoyance: Hey! Watch your dog!
+  →  <Subject 1> (S1) exclaims with light annoyance, <d>[English] Hey! Watch your dog!</d>
+  ```
+
+  The clause between tag and colon is the delivery, kept verbatim — the guide's example
+  carries the performance there, and a generated "says" would throw it away. IDs are never
+  written by hand: they are assigned in vocal-event order, reused by the same speaker at
+  every later line, and kept out of `retention_analysis`, which the guide forbids.
+  `@voice(a low male narrator)` covers a speaker with no panel slot, keyed on the
+  description so repeats keep one ID. `@audio2:` names a line carried by a reused track and
+  gets no ID at all, since a cue inside a soundtrack has no independent vocal source.
+
+  A shot whose only content is a spoken line is still a numbered shot — testing the prompt
+  alone would have dropped it once the dialogue was lifted out, losing the line and
+  shifting every later shot number, including the ones picture notes point at.
+
+- **Two more checks against the guide, reported in the live preview**: a speaker ID written
+  into a retention note, and a `detailed_description` outside the guide's 350–500 words.
+  The short-side warning waits for a third shot, since the guide warns against "mechanical
+  word-count adherence" and nagging a two-shot test would be noise.
+
 - **The chain node and the Director now share one reference loader.** The chain had grown
   its own copy that ignored the `ref_images` socket entirely and never fitted a keyframe to
   the canvas, so a chained render silently dropped references the Director would have sent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,15 @@ than that, and two of its sections were structurally missing from the output.
   preview warned that the clip was under the model card's minimum. It warns and honours the
   trim now, rather than warning and overriding it.
 
+- **Removed the Image Anchor.** An LTX concept that survived the port without ever being
+  connected to anything: `isAnchor` was written by the editor, round-tripped through the
+  timeline JSON, and read nowhere in Python — H3 has no per-keyframe guide strength for it
+  to drive. Its only observable effect was locking your prompt box and drawing an orange
+  glyph, so it looked like a feature while doing nothing but taking a field away. Old
+  timelines load unchanged; such a segment becomes an ordinary image with an empty prompt,
+  which is exactly what it already compiled to, and the flag is dropped on load rather than
+  riding along in the JSON forever.
+
 - **A reference video the browser cannot decode now works anyway.** The editor built the
   clip from a local blob through a `<video>` element, so it only accepted what the browser
   accepts — and a browser accepts far less than the renderer does. HEVC, ProRes and 10-bit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,10 +135,12 @@ than that, and two of its sections were structurally missing from the output.
   alone would have dropped it once the dialogue was lifted out, losing the line and
   shifting every later shot number, including the ones picture notes point at.
 
-- **Two more checks against the guide, reported in the live preview**: a speaker ID written
-  into a retention note, and a `detailed_description` outside the guide's 350–500 words.
-  The short-side warning waits for a third shot, since the guide warns against "mechanical
-  word-count adherence" and nagging a two-shot test would be noise.
+- **The live preview reports a speaker ID written into a retention note**, which the guide
+  forbids outright, and **shows `detailed_description`'s word count in its badge** against
+  the guide's suggested 350–500 for generation tasks. The count is a figure rather than a
+  warning: 350 words is a lot for a 5–15 second clip, so sitting under it is the ordinary
+  state here, and warning about it fired on essentially every timeline — which is how a
+  warnings area stops being read at all. Only overshooting the range is called out.
 
 - **The chain node and the Director now share one reference loader.** The chain had grown
   its own copy that ignored the `ref_images` socket entirely and never fitted a keyframe to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,41 @@ than that, and two of its sections were structurally missing from the output.
   hold a location or a look instead of a face. The panel grows from three slots to nine as
   you fill it, and `@ref1` … `@ref9` address them. `@char1` … `@char3` still resolve.
 
+- **A subject no longer has to have an image**, which is what made subjects unreachable on
+  the **Refs OFF (fl2va)** path: the slot's text boxes only appeared once something had
+  been dropped on it, and fl2va discards the drop. The one thing that path can carry was
+  behind the one thing it throws away.
+
+  [`references/base-en.txt`](https://github.com/MiniMax-AI/MiniMax-H3/blob/main/skills/h3-prompt-writing/references/base-en.txt)
+  has no `subject_definitions` section at all — with no reference files there is nothing to
+  declare — so a subject there lives in the prose, "established when a speaker first
+  appears" and referred to consistently afterwards. The slot now says both halves of that:
+
+  | Box | Becomes |
+  |---|---|
+  | **describes** | the full identity, written where the subject first appears |
+  | **called** | what to call it at every mention after that |
+
+  ```
+  @ref1 places a fresh loaf on the counter.
+  @ref1 says: First batch of the morning.
+
+  → [Shot 1] a middle-aged baker with a calm, slightly raspy voice places a fresh loaf on
+    the counter. the baker (S1) says, <d>[English] First batch of the morning.</d>
+  ```
+
+  Tags now resolve left to right through the finished video — the global block, then each
+  shot in turn, its prose before its dialogue — so "first" means first on screen and not
+  first in whichever box is being scanned. A subject introduced by its own spoken line is
+  named in full there. An empty **called** repeats the description at every mention, which
+  is what every timeline written before this field did. The same treatment applies with
+  references *on* to a slot that has a description but no image: no picture, no
+  `<Subject 1>` to lean on, so the prose has to carry the identity.
+
+  Images left in a slot with references off are kept — switching the toolbar back must not
+  cost the upload — but they are dimmed, and the prompt panel now says outright that
+  fl2va sends none of them.
+
 - **A reference no longer has to be followed exactly.** Every reference carries one of the
   guide's four **retention markers**, written into `retention_analysis` verbatim because
   the guide calls them "fixed English values in the output format":

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,19 @@ than that, and two of its sections were structurally missing from the output.
   state here, and warning about it fired on essentially every timeline — which is how a
   warnings area stops being read at all. Only overshooting the range is called out.
 
+- **A reference video the browser cannot decode now works anyway.** The editor built the
+  clip from a local blob through a `<video>` element, so it only accepted what the browser
+  accepts — and a browser accepts far less than the renderer does. HEVC, ProRes and 10-bit
+  footage inside perfectly ordinary `.mp4` and `.mov` files are all refused by Chrome and
+  all read fine by PyAV, which is what loads reference videos at generation time anyway.
+  Picking one did nothing at all, with a single `Motion video load error` in the console
+  and no message on screen.
+
+  A `probe_video` endpoint now supplies the duration, size and a first frame when the
+  browser gives up, so the clip lands on the track and renders normally. The editor accepts
+  what the renderer accepts. If the server cannot read it either, that finally says so on
+  screen instead of failing in silence.
+
 - **The chain node and the Director now share one reference loader.** The chain had grown
   its own copy that ignored the `ref_images` socket entirely and never fitted a keyframe to
   the canvas, so a chained render silently dropped references the Director would have sent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,90 @@
 # Changelog
 
+## 0.2.0
+
+Full-reference mode, from
+[`references/ref-en.txt`](https://github.com/MiniMax-AI/MiniMax-H3/blob/main/skills/h3-prompt-writing/references/ref-en.txt).
+Until now a reference image was always a character, always followed as tightly as
+possible, and a timeline image was always a frame anchor. The guide describes far more
+than that, and two of its sections were structurally missing from the output.
+
+- **A reference no longer has to be a character.** The guide defines `<Subject N>` as
+  "people, animals, or objects; scenes, backgrounds, or environments; clothing, props,
+  interfaces, or visual effects; styles, actions, expressions, or poses". Each slot now
+  carries a **kind** that supplies the noun when no description is written, so a slot can
+  hold a location or a look instead of a face. The panel grows from three slots to nine as
+  you fill it, and `@ref1` … `@ref9` address them. `@char1` … `@char3` still resolve.
+
+- **A reference no longer has to be followed exactly.** Every reference carries one of the
+  guide's four **retention markers**, written into `retention_analysis` verbatim because
+  the guide calls them "fixed English values in the output format":
+
+  | Marker | Meaning |
+  |---|---|
+  | `fully_preserved` | The defined role of the referenced content is fully preserved |
+  | `partially_preserved` | Still used, some defined characteristics changed |
+  | `attribute_transfer` | Its characteristics move to a different target subject |
+  | `weak_reference` | Broad similarity in style, category, composition or atmosphere only |
+
+  Audio uses its own set — `fully_copy`, `partially_copy`, `reference`, `weak_reference` —
+  because copying a signal and imitating one are different jobs. An off-spec value coming
+  from an edited timeline is clamped rather than passed through into the prompt.
+
+- **An image only gets a `<Picture N>` entry when it really is one.** The guide: "If an
+  image is used only to define a character, scene, costume, or style, do not create a
+  standalone picture entry. Instead, cite the image source inside the corresponding
+  `<Subject N>` definition." A timeline image can now be a **frame anchor** (unchanged),
+  a **storyboard** reference, or **subject-defining** — the last getting no picture entry
+  and, because it is no longer a keyframe, no longer cropped to the output canvas either.
+
+- **`subject_definitions` declares every label; `retention_analysis` scores every label.**
+  Both sections were previously incomplete: pictures were never declared, and retention
+  was prose. The two sections now follow the guide's shapes, and a subject's
+  `(appears in [Shot 1], [Shot 3])` is read back off the shot text rather than assumed.
+
+  ```
+  0.1.5   subject_definitions: <Subject 1> is the character shown in <Picture 1>.
+          retention_analysis: Keep the identity, face and clothing of <Subject 1>
+                              consistent across every shot. [Shot 1] begins from <Picture 2>.
+
+  0.2.0   subject_definitions: <Subject 1> is a woman in a red coat, shown in <Picture 1>.
+                               <Picture 2> is the first frame of [Shot 1].
+          retention_analysis:
+          <Subject 1> (appears in [Shot 1]): fully_preserved - the identity, face and
+            clothing of <Subject 1> are retained.
+          <Picture 2> ([Shot 1] first frame): fully_preserved - the framing and
+            composition of <Picture 2> are retained.
+  ```
+
+- **New `summary` section with a derived `[task type]` prefix** — `keyframe completion`,
+  `reference generation`, `audio reuse`, `audio reference`, combined with ` + ` in the
+  guide's own order. It is derived from what the references are *used for*, not from what
+  is connected: the guide warns that "the mere presence of video or audio does not
+  automatically create a corresponding task type", so a reference video supplying only
+  camera movement stays `reference generation`. The gear menu's **Task Type** field
+  overrides it, which is the only way to reach `video editing` and `video continuation` —
+  neither of which this node can produce on its own.
+
+- Frame anchors are also named inside their shot, as the guide's section 5.3 asks:
+  `[Shot 1] she enters. The shot begins from <Picture 2>.` The phrase goes after the
+  shot's own text, because a later shot opens `At 00:05.000, ` and a capitalised clause
+  cannot continue out of that comma.
+
+- **The chain node and the Director now share one reference loader.** The chain had grown
+  its own copy that ignored the `ref_images` socket entirely and never fitted a keyframe to
+  the canvas, so a chained render silently dropped references the Director would have sent.
+
+- **The live preview says when it cannot count.** Images arriving on the `ref_images`
+  socket are an upstream batch that does not exist until the graph runs, so the preview
+  could not number around them and silently showed `<Picture 2>` where the render would
+  send `<Picture 5>`. It now warns instead of quietly disagreeing.
+
+- Removed a note-pruning path that parsed `<Picture N>` back out of finished sentences to
+  drop trimmed references. Declarations are now built after the caps have trimmed, so
+  there is nothing to prune — and the per-type caps made that path unreachable anyway
+  (`images + videos` is at most 12 on its own, so the audio bucket always absorbs the
+  excess).
+
 ## 0.1.5
 
 - **Picture notes in `Refs ON` use the reference guide's own phrasing**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,25 @@ than that, and two of its sections were structurally missing from the output.
   state here, and warning about it fired on essentially every timeline — which is how a
   warnings area stops being read at all. Only overshooting the range is called out.
 
+- **Reference videos can be turned down when they run you out of memory.** Their frames are
+  VAE-encoded whole and the latents ride through every sampling step, so a long or large
+  clip is the usual cause of an OOM render — and the only way to shorten one was to drag
+  its edge on the track, with nothing anywhere saying what it currently was. Selecting a
+  clip now gives **start**, **frames** and **size** as numbers, with the seconds and the
+  model card's 2–15 s window shown beside them.
+
+  `start` and `frames` edit the segment's own trim and length rather than shadowing them,
+  so the track keeps showing exactly what will be sent. `size` is the short edge the clip
+  is decoded at, per clip because one reference may be carrying a look worth the pixels
+  while another is only carrying a camera move — and it is the biggest lever there is,
+  since memory goes with its square. The default is unchanged, so nothing moves until you
+  turn it down.
+
+- **A trimmed reference video is no longer silently lengthened.** The loader floored every
+  clip at 2 s, so trimming one shorter handed the VAE *more* than was asked for — while the
+  preview warned that the clip was under the model card's minimum. It warns and honours the
+  trim now, rather than warning and overriding it.
+
 - **A reference video the browser cannot decode now works anyway.** The editor built the
   clip from a local blob through a `<video>` element, so it only accepted what the browser
   accepts — and a browser accepts far less than the renderer does. HEVC, ProRes and 10-bit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,14 +30,22 @@ than that, and two of its sections were structurally missing from the output.
   because copying a signal and imitating one are different jobs. An off-spec value coming
   from an edited timeline is clamped rather than passed through into the prompt.
 
-- **The sentence after the marker is yours to write.** The guide's own retention lines name
-  actual features rather than a stock phrase — `fully_preserved - the Samoyed's thick white
-  fur, pointed ears, dark nose, and curved tail are retained`. Every reference has a
-  **retained** box for that: subject slots in the panel, timeline images, reference videos
-  and audio clips in the properties panel. Left empty, a sentence is generated from the
-  reference's kind, so the box overrides and never obliges. Subject slots and
-  subject-defining images carry two boxes, because they feed two different sections:
-  **describes** becomes the `<Subject N>` definition, **retained** the retention line.
+- **Both sentences about a reference are yours to write.** The guide's lines name actual
+  features rather than stock phrases — `fully_preserved - the Samoyed's thick white fur,
+  pointed ears, dark nose, and curved tail are retained` — and name relationships the
+  timeline cannot work out, like `<Audio 1> is the voice-timbre reference for <Subject 1>
+  (S1)`. Every reference therefore has up to two boxes, one per section it feeds:
+
+  | Box | Becomes |
+  |---|---|
+  | **describes** | the reference's line in `subject_definitions` — what it *is* |
+  | **retained** | the sentence after the marker in `retention_analysis` — what *survives* |
+
+  Subject slots carry both in the panel; timeline images, reference videos and audio clips
+  carry theirs in the properties panel. Either left empty falls back to the generated
+  sentence, so the boxes override and never oblige. Frame and storyboard anchors are the
+  one exception with no **describes** box: their declaration states where the image sits in
+  the video, which the timeline already knows and should not be contradicted.
 
 - **An image only gets a `<Picture N>` entry when it really is one.** The guide: "If an
   image is used only to define a character, scene, costume, or style, do not create a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,24 @@ than that, and two of its sections were structurally missing from the output.
   cost the upload — but they are dimmed, and the prompt panel now says outright that
   fl2va sends none of them.
 
+- **The fl2va prompt now stops at the fields the base guide defines.** Its structure is
+  closed — the alignment instruction, then "Three Core Fields (Required, in this order)" —
+  and `summary` is not among them; it belongs to the reference guide. A filled summary box
+  was emitting a section H3 was never trained to read on that path, task-type prefix and
+  all. The box is now hidden with references off and keeps its text for when the toolbar
+  goes back.
+
+  The other half of "required" also applies: `non_diegetic_music` is written as `N/A` when
+  the box is empty, which is the value both guides use for having none.
+  `overall_soundscape` deliberately does **not** get filled in the same way — there `N/A`
+  means the video was asked to be silent, which is a claim only you can make — so an empty
+  one is called out in the prompt panel instead. H3 generates the audio; leaving that field
+  out hands the whole soundtrack to a guess.
+
+  The 350-500 word figure is the reference guide's, for its own `detailed_description`.
+  The base guide gives no word count, so the fl2va path no longer cites one. The word
+  figure is still reported either way.
+
 - **A reference no longer has to be followed exactly.** Every reference carries one of the
   guide's four **retention markers**, written into `retention_analysis` verbatim because
   the guide calls them "fixed English values in the output format":

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Where things are:
 | `minimax_enhance.py` | Enhance Prompt (the vision-model node) |
 | `minimax_media.py` | media I/O and every HTTP route |
 | `js/minimax_director.js` | the timeline editor, forked from LTX Director |
-| `test_plan.py` | 93 offline checks over the planner |
+| `test_plan.py` | offline checks over the planner — it prints its own count |
 
 Python changes need a ComfyUI restart. JavaScript changes need a browser reload with the
 cache disabled.

--- a/README.md
+++ b/README.md
@@ -533,9 +533,18 @@ presence of video or audio does not automatically create a corresponding task ty
 gear menu's **Task Type** field overrides it, which is how you reach `video editing` and
 `video continuation` — neither of which this node has a path to produce on its own.
 
-The two sound sections and `summary` have their own boxes under the Global Prompt. What you type there
-goes straight into `overall_soundscape` and `non_diegetic_music`. Leave them empty and the
-sections are omitted entirely — an empty heading is worse than none.
+`summary` is the reference guide's section and appears on that path only. The base guide's
+structure is closed — the alignment instruction, then three required core fields — so with
+**Refs OFF** the box is hidden rather than writing a section H3 was never trained to read
+there. Your text is kept for when the toolbar goes back.
+
+The two sound sections have their own boxes under the Global Prompt, on both paths. What
+you type there goes straight into `overall_soundscape` and `non_diegetic_music`. Both
+guides list them as required, so an empty `non_diegetic_music` is written as `N/A` — their
+own value for having none. An empty `overall_soundscape` is **not** filled in the same way:
+there `N/A` says the video was asked to be silent, which is a claim only you can make, so
+the prompt panel points the omission out instead. H3 generates the audio; leaving that
+field out hands the whole soundtrack to a guess.
 
 `Audio:` / `Sound:` / `SFX:` and `Music:` / `Score:` lines written in the prompt text are
 still lifted into the same two sections, so older workflows and the Enhance node keep

--- a/README.md
+++ b/README.md
@@ -265,6 +265,12 @@ These are enforced, with a warning naming exactly what was dropped:
 
 Output envelope: 4–15 s at 24 fps. Aspect ratios 21:9, 16:9, 4:3, 1:1, 3:4, 9:16.
 
+**Video formats**: anything your ComfyUI can decode. The editor previews a reference video
+in the browser, which is fussier than the renderer — HEVC, ProRes and 10-bit footage inside
+an ordinary `.mp4` or `.mov` are commonly refused. When that happens the server reads the
+file instead and the clip lands on the track as usual; you may lose the filmstrip preview,
+never the clip. If the server cannot read it either, you get a message saying so.
+
 Anything you drop on a track is uploaded to `ComfyUI/input/whatdreamscost/`. That is the
 same folder LTX Director uses, deliberately — if you run both, assets and saved timelines
 carry over between them.

--- a/README.md
+++ b/README.md
@@ -312,20 +312,31 @@ survive, and the guide's own example is specific rather than generic:
 fur, pointed ears, dark nose, and curved tail are retained.
 ```
 
-Every reference has a **retained** box for exactly that. Subject slots carry theirs in the
-panel, next to the description; timeline images, reference videos and audio clips get one
-in the properties panel when they are selected. Leave it empty and a sentence is generated
-from the reference's kind instead — so the box is an override, never an obligation.
-
-Subject slots have two boxes, because they feed two different sections of the prompt:
+Every reference has boxes for exactly that — up to two, one per section of the prompt it
+feeds:
 
 | Box | Becomes |
 |---|---|
-| **describes** | the `<Subject N>` line in `subject_definitions` — what the thing *is* |
+| **describes** | the reference's line in `subject_definitions` — what the thing *is* |
 | **retained** | the sentence after the marker in `retention_analysis` — what must *survive* |
 
-An image on the timeline set to **defines a subject** gets both boxes too. Everything else
-gets **retained** alone.
+Subject slots carry both in the panel. Timeline images, reference videos and audio clips
+carry theirs in the properties panel when selected. Leave either empty and a sentence is
+generated instead — the boxes are overrides, never obligations.
+
+**describes** is what lets you write relationships the timeline cannot work out. The guide
+links a voice reference to the speaker it belongs to:
+
+```
+<Audio 1> is the voice-timbre reference for <Subject 1> (S1).
+```
+
+Type the part after `is` — the label is added for you, so it cannot come out wrong or
+doubled. Paste a whole line that already starts with its label and it is taken as written.
+
+Frame anchors and storyboard references are the one exception: they have **retained**
+alone. Their declaration states where the image sits in the video (`<Picture 2> is the
+first frame of [Shot 1].`), which the timeline already knows.
 
 ### Resizing the panel
 

--- a/README.md
+++ b/README.md
@@ -328,6 +328,42 @@ expressions, or poses" — so each slot carries a **kind** telling the prompt wh
 Slots start at three and a new empty one appears as you fill them, up to the nine-image
 cap.
 
+**A subject does not need an image.** On the **Refs OFF (fl2va)** path H3 is sent no
+reference images at all, so `references/base-en.txt` has no `subject_definitions` section
+to declare one in — a subject there is prose, "established when a speaker first appears"
+inside `integrated_multimodal_description` and referred to consistently after that. That
+is exactly what a slot with a description and no image does: `@ref1` drops the description
+in where the tag sits.
+
+Which is why the slot has a second box on that path:
+
+| Box | Becomes |
+|---|---|
+| **describes** | the full identity, written where the subject first appears |
+| **called** | what to call it at every mention after that |
+
+```
+@ref1 places a fresh loaf on the counter.
+@ref1 says: First batch of the morning.
+```
+```
+[Shot 1] a middle-aged baker with a calm, slightly raspy voice places a fresh loaf on the
+counter. the baker (S1) says, <d>[English] First batch of the morning.</d>
+```
+
+First means first in the finished video, across the global block and every shot in order,
+prose before dialogue — so a subject introduced by its own spoken line is named in full
+there and abbreviated afterwards. Leave **called** empty and the description is repeated
+at every mention, which is what timelines written before this field did.
+
+The same applies with references **on** to a slot that has a description but no image:
+without a picture there is no `<Subject 1>` to name it by, so the prose carries it. A slot
+that does have a picture ignores **called** — `<Subject 1>` is already a stable handle
+that survives every cut.
+
+Images left in a slot on the fl2va path are kept, so switching the toolbar back costs you
+nothing, but they are dimmed and the prompt panel says they are not being sent.
+
 ### How closely a reference is followed
 
 Every reference carries a **retention marker** — the guide's term for "exactly or

--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ and no longer always followed exactly: subject slots carry a **kind** (scene, pr
 `weak_reference`, plus a box to write the sentence that follows it in your own words.
 Timeline images can be frame anchors, storyboard references, or subject-defining images
 that get no `<Picture>` entry at all. Prompts gain a `summary` section with a derived
-`[task type]` prefix, and `retention_analysis` uses the guide's own line format. The
-reference panel resizes, with the extra height going to the image previews.
+`[task type]` prefix, and `retention_analysis` uses the guide's own line format. Dialogue
+written as `@ref1 says: …` is given speaker IDs and `<d>` tags for you. The reference panel
+resizes, with the extra height going to the image previews.
 
 **0.1.5** · 2026-08-06 — picture notes in `Refs ON` now use the reference guide's own
 phrasing for frame anchors: `[Shot 1] begins from <Picture 1>`, `ends on`, and
@@ -337,6 +338,41 @@ doubled. Paste a whole line that already starts with its label and it is taken a
 Frame anchors and storyboard references are the one exception: they have **retained**
 alone. Their declaration states where the image sits in the video (`<Picture 2> is the
 first frame of [Shot 1].`), which the timeline already knows.
+
+### Dialogue
+
+A line in a shot prompt that **starts** with a reference tag and contains a colon is
+dialogue. Everything between the tag and the colon is how it is delivered:
+
+```
+@ref1 exclaims with light annoyance: Hey! Watch your dog!
+```
+
+becomes
+
+```
+<Subject 1> (S1) exclaims with light annoyance, <d>[English] Hey! Watch your dog!</d>
+```
+
+`(S1)` is a **speaker ID**. You never write one: they are handed out in the order people
+actually speak across the whole timeline, and the same speaker keeps the same ID at every
+later line — so a subject who talks in shots 1 and 3 is `(S1)` in both. They are also kept
+out of `retention_analysis`, which the guide forbids; type one into a **retained** box and
+the preview says so.
+
+| Write | For |
+|---|---|
+| `@ref1 says: …` | a subject from the panel — the delivery defaults to `says` |
+| `@ref1 [French] murmure: …` | another language; `[English]` is assumed |
+| `@voice(a low male narrator) says: …` | someone with no panel slot. Reuse the same description and they keep one ID |
+| `@audio2: …` | words carried by a reused track. Names `<Audio 2>` as the source and gets **no** speaker ID, per the guide |
+
+Only a line that *starts* with a tag counts, so prose that merely mentions `@ref1` or
+contains a colon is left alone — the same rule the `Audio:` / `Music:` lines follow. A shot
+whose only content is a spoken line is still a numbered shot.
+
+`<scenetrans>` and `<cutoff>`, for dialogue crossing a cut or speech that is cut short, are
+passed through untouched if you type them.
 
 ### Resizing the panel
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ see the exact prompt the model will receive while you are still editing it.
 
 [![license](https://img.shields.io/badge/license-GPL--3.0-blue)](LICENSE)
 [![ComfyUI](https://img.shields.io/badge/ComfyUI-%E2%89%A5%200.30.0-1a1a1a)](https://github.com/comfyanonymous/ComfyUI)
-[![version](https://img.shields.io/badge/version-0.1.5-brightgreen)](CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-0.2.0-brightgreen)](CHANGELOG.md)
 
 ![The MiniMax H3 Director node](docs/images/director-node.png)
 
@@ -43,6 +43,14 @@ see the exact prompt the model will receive while you are still editing it.
 ---
 
 ## News
+
+**0.2.0** · 2026-08-09 — full reference mode. A reference is no longer always a character
+and no longer always followed exactly: subject slots carry a **kind** (scene, prop, style,
+…) and every reference carries a **retention marker** from `fully_preserved` to
+`weak_reference`. Timeline images can be frame anchors, storyboard references, or
+subject-defining images that get no `<Picture>` entry at all. Prompts gain a `summary`
+section with a derived `[task type]` prefix, and `retention_analysis` now uses the guide's
+own line format.
 
 **0.1.5** · 2026-08-06 — picture notes in `Refs ON` now use the reference guide's own
 phrasing for frame anchors: `[Shot 1] begins from <Picture 1>`, `ends on`, and
@@ -96,8 +104,8 @@ Four nodes, category **MiniMax H3**:
 Editing features carried over from LTX Director: main track, reference-video track, audio
 track, ruler in seconds or frames, drag / resize / copy / paste, prompt zones per segment,
 waveform preview, filename labels, gear menu, workspace folder, chunked upload for large
-videos, drag-and-drop straight onto the node, and the `@char1` / `@char2` / `@char3`
-character slots including the optional local VLM "Analyze" button (Ollama / LM Studio /
+videos, drag-and-drop straight onto the node, and the `@ref1` … `@ref9` subject
+slots including the optional local VLM "Analyze" button (Ollama / LM Studio /
 any OpenAI-compatible endpoint) with automatic VRAM release before a run.
 
 ## Requirements
@@ -175,7 +183,7 @@ ComfyUI/models/
 | Toolbar switch | Checkpoint | Use it for |
 |---|---|---|
 | **Refs OFF** | `minimax_h3_fl2va_*` | text→video, and first/last keyframes from the timeline |
-| **Refs ON** | `minimax_h3_ref2va_*` | character slots, reference images, reference videos, reference audio |
+| **Refs ON** | `minimax_h3_ref2va_*` | subject slots, reference images, reference videos, reference audio |
 
 Connect both to the Director's two model inputs and the toolbar switch picks the right
 one. Connecting only one is fine — the node warns rather than silently using the wrong path.
@@ -234,6 +242,7 @@ readable; open them if you want to change sampler, scheduler or steps.
 | **Main** | prompt zones | `[Shot N]` entries with timestamps |
 | **Reference video** | video clips | `<Video k>` motion/style references |
 | **Audio** | music, SFX | `<Audio j>` reference and/or the muxed soundtrack |
+| **Subject slots** | images | `<Subject N>` definitions — people, scenes, props, styles |
 
 ### Reference limits
 
@@ -242,7 +251,7 @@ These are enforced, with a warning naming exactly what was dropped:
 
 | Limit | Value |
 |---|---|
-| Reference images | ≤ 9 — the three character slots *and* the `ref_images` input share this pool |
+| Reference images | ≤ 9 — the subject slots *and* the `ref_images` input share this pool |
 | Reference videos | ≤ 3 clips, each 2–15 s, **≤ 15 s total** |
 | Reference audio | ≤ 3 clips |
 | **All types together** | **≤ 12 files** |
@@ -253,14 +262,61 @@ Anything you drop on a track is uploaded to `ComfyUI/input/whatdreamscost/`. Tha
 same folder LTX Director uses, deliberately — if you run both, assets and saved timelines
 carry over between them.
 
-### Character slots and the Analyze button
+### Subject slots and the Analyze button
 
-Drop a face or a full-body shot into `@char1` … `@char3` and write `@char1` in a prompt;
-it expands to `<Subject 1>` (MiniMax notation) or `<Picture 1>` (ComfyUI notation) and the
-image is attached as a reference. This is the **Refs ON (ref2va)** path.
+Drop an image into a slot and write `@ref1` in a prompt; it expands to `<Subject 1>`
+(MiniMax notation) or `<Picture 1>` (ComfyUI notation) and the image is attached as a
+reference. This is the **Refs ON (ref2va)** path. `@char1` … `@char3` still work, so
+prompts written against the old three-slot panel keep resolving.
+
+A slot is **not** only for characters. The reference guide defines `<Subject N>` as any
+reusable visible content — "people, animals, or objects; scenes, backgrounds, or
+environments; clothing, props, interfaces, or visual effects; styles, actions,
+expressions, or poses" — so each slot carries a **kind** telling the prompt what it is:
+
+| Control | What it does |
+|---|---|
+| **kind** | Supplies the noun in `<Subject N> is the environment shown in <Picture 1>.` A typed description replaces it entirely. |
+| **retention** | How closely to follow it. Written into `retention_analysis` verbatim. |
+
+Slots start at three and a new empty one appears as you fill them, up to the nine-image
+cap.
+
+### How closely a reference is followed
+
+Every reference carries a **retention marker** — the guide's term for "exactly or
+loosely". These are fixed English values written straight into the prompt, so the
+dropdowns show them under their own names rather than friendlier ones:
+
+| Marker | Meaning |
+|---|---|
+| `fully_preserved` | The defined role of the referenced content is fully preserved |
+| `partially_preserved` | Still used, but some defined characteristics change |
+| `attribute_transfer` | Its characteristics move onto a different target subject |
+| `weak_reference` | Broad similarity in style, category, composition or atmosphere only |
+
+Audio has its own set, because copying a signal and imitating one are different jobs:
+`fully_copy`, `partially_copy`, `reference`, `weak_reference`.
+
+Right-click any reference — a timeline image, a reference video, an audio clip — to set
+its marker. Subject slots have theirs in the panel.
+
+### What an image is *for*
+
+The guide only gives an image its own `<Picture N>` entry when the image really is a
+frame. Right-click a timeline image to say which of the three it is:
+
+| Used as | Result |
+|---|---|
+| **frame anchor** (default) | `<Picture 2> is the first frame of [Shot 1].` — its position on the timeline decides first / last / keyframe |
+| **storyboard** | `<Picture 3> is a storyboard reference for [Shot 2], defining its viewpoint, subject placement, and shot order.` |
+| **defines a subject** | No `<Picture>` entry at all. Cited inside a `<Subject N>` line instead, exactly as the guide requires for an image that "is used only to define a character, scene, costume, or style". |
+
+A subject-only image also stops being a keyframe, so it is no longer fitted to the output
+canvas — the full reference reaches the model instead of a cropped one.
 
 **Analyze** is optional and off the critical path. It sends the slot image to a local
-vision model and pastes back a one-line description, so `@char1` still means something in
+vision model and pastes back a one-line description, so `@ref1` still means something in
 **Refs OFF** mode, where H3 gets no image at all. Nothing is installed for you and nothing
 is sent anywhere unless you press the button.
 
@@ -285,12 +341,20 @@ Gear menu → **Prompt Format**. The default is **MiniMax**, the notation from t
 `VIDEO_PROMPT_WRITING_GUIDE`:
 
 ```
-subject_definitions: <Subject 1> is the character shown in <Picture 1>.
+subject_definitions: <Subject 1> is a baker in a flour-dusted apron, shown in <Picture 1>.
+<Subject 2> is the environment shown in <Picture 2>. <Picture 3> is the first frame of [Shot 1].
 
-retention_analysis: Keep the identity, face and clothing of <Subject 1> consistent across every shot.
+summary: [keyframe completion + reference generation] The target video follows <Subject 1>
+opening the bakery.
 
-detailed_description: Live-action, cinematic. [Shot 1] the baker opens the shutters
-[Shot 2] At 00:01.500, <Subject 1> lifts the loaf onto the counter
+retention_analysis:
+<Subject 1> (appears in [Shot 1], [Shot 2]): fully_preserved - the identity, face and clothing of <Subject 1> are retained.
+<Subject 2> (appears in [Shot 1]): weak_reference - only a broad similarity to <Subject 2> in style, category, composition and atmosphere is kept.
+<Picture 3> ([Shot 1] first frame): fully_preserved - the framing and composition of <Picture 3> are retained.
+
+detailed_description: Live-action, cinematic. [Shot 1] the baker opens the shutters.
+The shot begins from <Picture 3>. [Shot 2] At 00:01.500, <Subject 1> lifts the loaf onto
+the counter
 
 overall_soundscape: street ambience, a distant tram
 non_diegetic_music: soft piano
@@ -298,6 +362,14 @@ non_diegetic_music: soft piano
 
 The first shot carries no timestamp; every later cut carries a strictly increasing
 `MM:SS.mmm` one. Sections appear only when there is something real to put in them.
+
+`summary` opens with a **task type** derived from what the references are actually used
+for — `keyframe completion`, `reference generation`, `audio reuse`, `audio reference`,
+joined with ` + `. A reference video that only supplies camera movement counts as
+`reference generation`, never `video editing`; the guide is explicit that "the mere
+presence of video or audio does not automatically create a corresponding task type". The
+gear menu's **Task Type** field overrides it, which is how you reach `video editing` and
+`video continuation` — neither of which this node has a path to produce on its own.
 
 The two sound sections have their own boxes under the Global Prompt. What you type there
 goes straight into `overall_soundscape` and `non_diegetic_music`. Leave them empty and the
@@ -310,8 +382,13 @@ working. A filled box wins over a lifted line.
 **`<Subject N>` vs `<Picture N>`** is worth knowing: the guide reserves `<Subject N>` for
 reusable content — a person, a place, a style — and `<Picture N>` for concrete frame
 anchors. ComfyUI's tokenizer only ever labels images `<Picture i>`, so
-`subject_definitions` binds the two. That is what lets a character keep one name across
-every cut. `@char1` therefore expands to `<Subject 1>` here.
+`subject_definitions` binds the two. That is what lets a subject keep one name across
+every cut. `@ref1` therefore expands to `<Subject 1>` here.
+
+Note what that means for a subject slot's image: it is passed to the model as
+`<Picture 1>`, but it gets **no** `<Picture 1>` declaration of its own. The guide is
+explicit — an image used only to define something is cited inside its `<Subject N>` line
+instead. Only real frame and storyboard anchors are declared as pictures.
 
 **ComfyUI** switches to `[0s-1.5s] …`, the notation the ComfyUI H3 templates use. Same
 timeline, same references, only the wording changes — so it is a fair A/B.

--- a/README.md
+++ b/README.md
@@ -265,6 +265,39 @@ These are enforced, with a warning naming exactly what was dropped:
 
 Output envelope: 4–15 s at 24 fps. Aspect ratios 21:9, 16:9, 4:3, 1:1, 3:4, 9:16.
 
+### When a reference video runs you out of memory
+
+A reference video is the most expensive thing you can put on the timeline. Its frames are
+VAE-encoded **whole**, and the resulting latents then ride through every sampling step — so
+cost scales with frames × width × height, and a long or large clip is the usual cause of an
+OOM render.
+
+Select the clip on the reference-video track and the properties panel gives you the three
+numbers that matter:
+
+| Field | Effect |
+|---|---|
+| **start** | First frame taken from the source. Lets you use the interesting middle of a clip without paying for the run-up. |
+| **frames** | How many frames are encoded — linear on memory. At 24 fps this is also the clip's length, so the panel shows the seconds beside it and flags the model card's 2–15 s window. |
+| **size** | Short edge it is decoded at. **The biggest lever**: memory goes with the square, so 384 costs about a quarter of 768. |
+
+Rough figures for a 5 s output (124 frames), pixel data alone, before VAE activations:
+
+| size | per frame | 124 frames |
+|---|---|---|
+| 768 (default) | 1.03 MP | ~1.5 GB |
+| 512 | 0.46 MP | ~683 MB |
+| 384 | 0.26 MP | ~384 MB |
+| 256 | 0.11 MP | ~171 MB |
+
+Try **size** first — a `<Video k>` contributes movement and camera work, which survives a
+lower resolution far better than a character's face would. Nothing changes unless you turn
+it down; the default is exactly what the node used before.
+
+**Do not** expect a lower frame rate to help: H3 reads reference video at 24 fps and stamps
+its own timestamps on that basis, so feeding it fewer frames per second would tell the
+model the motion is faster than it is. Frames and duration are the same dial.
+
 **Video formats**: anything your ComfyUI can decode. The editor previews a reference video
 in the browser, which is fussier than the renderer — HEVC, ProRes and 10-bit footage inside
 an ordinary `.mp4` or `.mov` are commonly refused. When that happens the server reads the

--- a/README.md
+++ b/README.md
@@ -209,8 +209,13 @@ Other quantisations on the repo work too: `*_bf16` (66 GB, best quality),
 5. **Run.**
 
 Read the **COMPILED PROMPT** panel under the timeline before running: it shows the exact
-text the model will get, the shot count, the frame count and the reference tally, plus
-warnings for the things that silently bite.
+text the model will get, the shot count, the frame count, the reference tally and the
+`detailed_description` word count, plus warnings for the things that silently bite.
+
+The word count is there because the guide suggests **350–500 words** for generation tasks,
+which is more than most people write. It is a figure, not a verdict — being under it is
+perfectly normal for a short clip, and the guide itself warns against "mechanical
+word-count adherence". Only going *past* 500 raises a warning.
 
 Defaults that matter, if you wire it yourself:
 

--- a/README.md
+++ b/README.md
@@ -47,10 +47,11 @@ see the exact prompt the model will receive while you are still editing it.
 **0.2.0** · 2026-08-09 — full reference mode. A reference is no longer always a character
 and no longer always followed exactly: subject slots carry a **kind** (scene, prop, style,
 …) and every reference carries a **retention marker** from `fully_preserved` to
-`weak_reference`. Timeline images can be frame anchors, storyboard references, or
-subject-defining images that get no `<Picture>` entry at all. Prompts gain a `summary`
-section with a derived `[task type]` prefix, and `retention_analysis` now uses the guide's
-own line format.
+`weak_reference`, plus a box to write the sentence that follows it in your own words.
+Timeline images can be frame anchors, storyboard references, or subject-defining images
+that get no `<Picture>` entry at all. Prompts gain a `summary` section with a derived
+`[task type]` prefix, and `retention_analysis` uses the guide's own line format. The
+reference panel resizes, with the extra height going to the image previews.
 
 **0.1.5** · 2026-08-06 — picture notes in `Refs ON` now use the reference guide's own
 phrasing for frame anchors: `[Shot 1] begins from <Picture 1>`, `ends on`, and
@@ -301,6 +302,38 @@ Audio has its own set, because copying a signal and imitating one are different 
 Right-click any reference — a timeline image, a reference video, an audio clip — to set
 its marker. Subject slots have theirs in the panel.
 
+### Saying what is retained
+
+The marker is only half the line. After it comes a sentence naming what actually has to
+survive, and the guide's own example is specific rather than generic:
+
+```
+<Subject 2> (appears in [Shot 1], [Shot 2]): fully_preserved - the Samoyed's thick white
+fur, pointed ears, dark nose, and curved tail are retained.
+```
+
+Every reference has a **retained** box for exactly that. Subject slots carry theirs in the
+panel, next to the description; timeline images, reference videos and audio clips get one
+in the properties panel when they are selected. Leave it empty and a sentence is generated
+from the reference's kind instead — so the box is an override, never an obligation.
+
+Subject slots have two boxes, because they feed two different sections of the prompt:
+
+| Box | Becomes |
+|---|---|
+| **describes** | the `<Subject N>` line in `subject_definitions` — what the thing *is* |
+| **retained** | the sentence after the marker in `retention_analysis` — what must *survive* |
+
+An image on the timeline set to **defines a subject** gets both boxes too. Everything else
+gets **retained** alone.
+
+### Resizing the panel
+
+The reference panel drags from the strip along its bottom edge, like the prompt and global
+prompt panels. All the extra height goes to the image previews rather than the text boxes,
+so drag it taller when you need to actually see what you are referencing. The height is
+remembered per node.
+
 ### What an image is *for*
 
 The guide only gives an image its own `<Picture N>` entry when the image really is a
@@ -341,14 +374,16 @@ Gear menu → **Prompt Format**. The default is **MiniMax**, the notation from t
 `VIDEO_PROMPT_WRITING_GUIDE`:
 
 ```
-subject_definitions: <Subject 1> is a baker in a flour-dusted apron, shown in <Picture 1>.
-<Subject 2> is the environment shown in <Picture 2>. <Picture 3> is the first frame of [Shot 1].
+subject_definitions:
+<Subject 1> is a baker in a flour-dusted apron, shown in <Picture 1>.
+<Subject 2> is the environment shown in <Picture 2>.
+<Picture 3> is the first frame of [Shot 1].
 
 summary: [keyframe completion + reference generation] The target video follows <Subject 1>
 opening the bakery.
 
 retention_analysis:
-<Subject 1> (appears in [Shot 1], [Shot 2]): fully_preserved - the identity, face and clothing of <Subject 1> are retained.
+<Subject 1> (appears in [Shot 1], [Shot 2]): fully_preserved - the flour-dusted apron and the wire-rimmed glasses are retained.
 <Subject 2> (appears in [Shot 1]): weak_reference - only a broad similarity to <Subject 2> in style, category, composition and atmosphere is kept.
 <Picture 3> ([Shot 1] first frame): fully_preserved - the framing and composition of <Picture 3> are retained.
 
@@ -371,7 +406,7 @@ presence of video or audio does not automatically create a corresponding task ty
 gear menu's **Task Type** field overrides it, which is how you reach `video editing` and
 `video continuation` — neither of which this node has a path to produce on its own.
 
-The two sound sections have their own boxes under the Global Prompt. What you type there
+The two sound sections and `summary` have their own boxes under the Global Prompt. What you type there
 goes straight into `overall_soundscape` and `non_diegetic_music`. Leave them empty and the
 sections are omitted entirely — an empty heading is worse than none.
 

--- a/js/minimax_director.js
+++ b/js/minimax_director.js
@@ -2622,6 +2622,7 @@ class TimelineEditor {
       // and the subject panel swaps `retained` for `called` on the same switch
       this.updateUIFromSelection();
       this.updateCharacterSlotsUI();
+      this._syncSummaryField();
     });
     this.refOptionSelect = refOptionSelect;
 
@@ -3221,6 +3222,11 @@ class TimelineEditor {
     this.summaryInput = makeSoundField(
       "summary", "summary",
       "One paragraph on the target video and what each reference is for. The [task type] prefix is added for you.");
+    // ...and only the reference guide has it. The base guide's structure is closed —
+    // the alignment instruction, then three required core fields — so with refs off the
+    // box would offer a section the prompt cannot carry. The text is kept either way.
+    this.summaryField = this.summaryInput.parentElement;
+    this._syncSummaryField();
 
     this.globalPromptInput.addEventListener("input", (e) => {
       const val = e.target.value;
@@ -4336,6 +4342,8 @@ class TimelineEditor {
     if (this.refOptionSelect) {
       this.refOptionSelect.value = this.timeline.reference_mode || "OFF";
     }
+    // and everything else the switch governs, for a workflow restored on the fl2va path
+    this._syncSummaryField();
 
     this.container.appendChild(this.wrapper);
   }
@@ -9591,6 +9599,13 @@ class TimelineEditor {
 
   // Three always visible, then one empty slot ahead of whatever is filled, so the panel
   // grows only as far as it is used instead of showing nine empty boxes on day one.
+  // Shown only on the ref2va path, where `summary` is a section of the prompt.
+  _syncSummaryField() {
+    if (!this.summaryField) return;
+    const refsOn = String(this.timeline.reference_mode || "OFF").toUpperCase() !== "OFF";
+    this.summaryField.style.display = refsOn ? "" : "none";
+  }
+
   // A slot counts as used once it holds an image *or* a description. With refs off the
   // image is discarded by the render, so a written subject is all a slot can ever be
   // there — gating the panel on images alone capped that path at three empty boxes.

--- a/js/minimax_director.js
+++ b/js/minimax_director.js
@@ -5865,11 +5865,16 @@ class TimelineEditor {
     this.refNoteRow.style.display = "flex";
     this._growPropForRefNote();
 
-    // `describes` only means something for an image that defines a subject rather than
-    // anchoring a frame — every other reference has just the one sentence.
-    const describes = this.selectionType === "image" && seg.refRole === "subject";
+    // `describes` writes the reference's line in subject_definitions. A frame or
+    // storyboard anchor is the exception: its declaration states where the image sits in
+    // the video, which the timeline already knows and the user should not contradict.
+    const describes = this.selectionType !== "image" || seg.refRole === "subject";
     this.refDescField.style.display = describes ? "" : "none";
     if (describes) this.refDescInput.value = seg.refDesc || "";
+    this.refDescInput.placeholder = {
+      audio: "e.g. the voice-timbre reference for <Subject 1>",
+      motion: "e.g. the source of the camera move and cut rhythm",
+    }[this.selectionType] || "what this image defines, e.g. a long red wool coat";
     this.refNoteInput.value = seg.refNote || "";
     this.refNoteInput.placeholder = this.selectionType === "audio"
       ? "what the target keeps from this audio — leave empty for the default"

--- a/js/minimax_director.js
+++ b/js/minimax_director.js
@@ -921,6 +921,14 @@ function subjectPanelHeight(slotCount, slotHeight) {
     + SUBJECT_STEPPER_H;
 }
 
+// The properties panel builds its rows with innerHTML, so text the user typed has to be
+// neutralised on the way in: a description holding a `<` took the row's markup with it.
+function escapeAttr(text) {
+  return String(text == null ? "" : text)
+    .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+}
+
 const SUBJECT_SLOTS_DEFAULT = 3;
 function clampSubjectSlots(n) {
   const v = parseInt(n, 10);
@@ -6266,16 +6274,9 @@ class TimelineEditor {
       // "<Audio 1> is the voice-timbre reference for <Subject 1> (S1)." — and without
       // somewhere to say it, a second voice reference is just another numbered clip with
       // no way to tell the model who is speaking (issue #10).
-      const chars = this.subjectSlots();
-      const options = ['<option value="">— not a specific subject —</option>'].concat(
-        chars.map((c, i) => {
-          const desc = (c.description || "").trim();
-          const label = desc ? `Subject ${i + 1} — ${desc.slice(0, 40)}` : `Subject ${i + 1}`;
-          const sel = String(seg.subject || "") === String(i + 1) ? " selected" : "";
-          return `<option value="${i + 1}"${sel}>${label}</option>`;
-        })).join("");
+      const options = this._audioSubjectOptions(seg);
       this.audioInfoArea.innerHTML = `
-        File: <span>${seg.fileName || "Unknown"}</span><br>
+        File: <span>${escapeAttr(seg.fileName || "Unknown")}</span><br>
         Length: <span>${this.formatTime(seg.audioDurationFrames)}</span> Output Length: <span>${this.formatTime(seg.length)}</span><br>
         Trim-in: <span>${this.formatTime(Math.round(seg.trimStart))}</span> Trim-Out: <span>${this.formatTime(Math.round(seg.audioDurationFrames - (seg.trimStart + seg.length)))}</span><br>
         <label class="mmxd-audio-subject-label">Voice of:
@@ -9669,6 +9670,50 @@ class TimelineEditor {
     if (!this.summaryField) return;
     const refsOn = String(this.timeline.reference_mode || "OFF").toUpperCase() !== "OFF";
     this.summaryField.style.display = refsOn ? "" : "none";
+  }
+
+  // Which slot is which `<Subject N>` is the planner's answer, taken from the last compile
+  // rather than worked out again here: only slots that hand over a reference image are
+  // numbered, so slot 2 is <Subject 1> when slot 1 is empty, and a menu that counted slots
+  // named a subject the prompt did not have.
+  //
+  // A slot with no number has no label for a clip to be tied to — its description goes into
+  // the prose instead — so it is offered as unavailable, with the reason, rather than
+  // taking the click and doing nothing with it.
+  _audioSubjectOptions(seg) {
+    const subjectOfSlot = this.node?._mmxSubjectOfSlot;
+    const refsOn = String(this.timeline.reference_mode || "OFF").toUpperCase() !== "OFF";
+    return ['<option value="">— not a specific subject —</option>'].concat(
+      this.subjectSlots().map((c, i) => {
+        const desc = escapeAttr((c.description || "").trim().slice(0, 40));
+        const tail = desc ? ` — ${desc}` : "";
+        const sel = String(seg.subject || "") === String(i + 1) ? " selected" : "";
+        const subject = subjectOfSlot?.[String(i + 1)];
+        if (subject) {
+          return `<option value="${i + 1}"${sel}>Subject ${subject}${tail}</option>`;
+        }
+        // No compile has answered yet: say nothing rather than guess a number
+        if (!subjectOfSlot) {
+          return `<option value="${i + 1}"${sel}>Slot ${i + 1}${tail}</option>`;
+        }
+        const why = !refsOn ? "Refs OFF sends no references"
+          : (c.images && c.images.length) ? "not among the references sent"
+          : "needs a reference image";
+        return `<option value="" disabled${sel}>Slot ${i + 1}${tail} — ${why}</option>`;
+      })).join("");
+  }
+
+  // The menu is built when a clip is selected, but what it says depends on the panel above
+  // it: drop an image into a slot and that slot becomes bindable, delete one and it stops.
+  // Only the options are replaced, so the `change` listener on the <select> survives — and
+  // not while it has focus, which would shut an open menu under the pointer.
+  refreshAudioSubjectMenu() {
+    if (this.selectionType !== "audio") return;
+    const sel = this.audioInfoArea?.querySelector(".mmxd-audio-subject");
+    if (!sel || document.activeElement === sel) return;
+    const seg = this.timeline.audioSegments?.[this.selectedIndex];
+    if (!seg) return;
+    sel.innerHTML = this._audioSubjectOptions(seg);
   }
 
   // The stepper owns this number and nothing else writes it. It used to grow on its own as
@@ -13828,6 +13873,12 @@ app.registerExtension({
             const d = await resp.json();
             if (d.status !== "success") throw new Error(d.message || "compile failed");
             pText.textContent = d.prompt || "";
+            // slot -> <Subject N>, straight from the planner, for the properties panel's
+            // "Voice of" menu to label itself by. Cached because that menu is built on
+            // selection, not on this refresh — and re-read here, because adding or deleting
+            // a reference image changes what it should say while it is already on screen.
+            self._mmxSubjectOfSlot = d.subject_of_slot || {};
+            self._timelineEditor?.refreshAudioSubjectMenu?.();
             // Keep the textarea in step with what is stored, but never while it has the
             // caret — clobbering someone's sentence mid-word is unforgivable.
             if (d.overridden && document.activeElement !== pEdit

--- a/js/minimax_director.js
+++ b/js/minimax_director.js
@@ -667,6 +667,10 @@ const STYLES = `
   .mmxd-character-slot.drag-over { border-color: #4fff8f; background: rgba(79, 255, 143, 0.05); }
   .mmxd-character-label { font-size: 10px; font-weight: bold; color: #888; margin-bottom: 2px; pointer-events: none; }
   .mmxd-character-placeholder { font-size: 9px; color: #666; text-align: center; pointer-events: none; margin-top: 10px; }
+  /* the empty slot's drop target: takes the same slack the previews row takes, so the
+     text boxes below it sit at the same height whether or not an image has been dropped */
+  .mmxd-character-dropzone { display: flex; flex-direction: column; align-items: center; justify-content: center; width: 100%; flex: 1 1 auto; min-height: 44px; pointer-events: none; }
+  .mmxd-character-dropzone .mmxd-character-placeholder { margin-top: 4px; }
   /* the only part of a slot that flexes, so dragging the panel taller grows the images */
   .mmxd-character-previews-row { display: flex; width: 100%; flex: 1 1 auto; min-height: 44px; gap: 4px; position: relative; }
   .mmxd-character-preview-wrapper { flex: 1; height: 100%; position: relative; overflow: hidden; border-radius: 3px; background: #111; }
@@ -908,8 +912,8 @@ function subjectPanelHeight(slotCount, slotHeight) {
 }
 
 function emptySubjectSlot() {
-  return { images: [], description: "", kind: "person", retention: "fully_preserved",
-           retentionNote: "" };
+  return { images: [], description: "", shortName: "", kind: "person",
+           retention: "fully_preserved", retentionNote: "" };
 }
 
 // Old timelines wrote `characters` and had neither kind nor retention. Reading them back
@@ -920,6 +924,7 @@ function normaliseSubjectSlots(raw) {
   const out = list.slice(0, MAX_SUBJECT_SLOTS).map((c) => ({
     images: Array.isArray(c.images) ? c.images : [],
     description: c.description || "",
+    shortName: c.shortName || "",
     kind: SUBJECT_KIND_OPTIONS.some(o => o.value === c.kind) ? c.kind : "person",
     retention: RETENTION_OPTIONS.some(o => o.value === c.retention)
       ? c.retention : "fully_preserved",
@@ -2613,8 +2618,10 @@ class TimelineEditor {
       this.timeline.reference_mode = e.target.value;
       this.commitChanges();
       // the describes/retained strip only exists in ref2va, so it has to appear and
-      // disappear with the switch rather than waiting for the next selection change
+      // disappear with the switch rather than waiting for the next selection change —
+      // and the subject panel swaps `retained` for `called` on the same switch
       this.updateUIFromSelection();
+      this.updateCharacterSlotsUI();
     });
     this.refOptionSelect = refOptionSelect;
 
@@ -9584,10 +9591,15 @@ class TimelineEditor {
 
   // Three always visible, then one empty slot ahead of whatever is filled, so the panel
   // grows only as far as it is used instead of showing nine empty boxes on day one.
+  // A slot counts as used once it holds an image *or* a description. With refs off the
+  // image is discarded by the render, so a written subject is all a slot can ever be
+  // there — gating the panel on images alone capped that path at three empty boxes.
   visibleSlotCount() {
     const slots = this.subjectSlots();
     let filled = 0;
-    slots.forEach((s, i) => { if (s.images && s.images.length) filled = i + 1; });
+    slots.forEach((s, i) => {
+      if ((s.images && s.images.length) || (s.description || "").trim()) filled = i + 1;
+    });
     return Math.max(3, Math.min(MAX_SUBJECT_SLOTS, filled + 1));
   }
 
@@ -9848,9 +9860,23 @@ class TimelineEditor {
       const data = subjects[i] || emptySubjectSlot();
       slot.innerHTML = "";
 
-      if (data.images && data.images.length > 0) {
+      // A subject is a description first and an image second. The image is what earns it
+      // a <Subject N> label on the ref2va path; on fl2va the image is discarded by the
+      // render and the description is the whole subject. So the text boxes are always
+      // here, and only the controls that can actually reach the prompt come and go.
+      const refsOn = String(this.timeline.reference_mode || "OFF").toUpperCase() !== "OFF";
+      const hasImages = !!(data.images && data.images.length);
+
+      if (hasImages) {
         const previewsRow = document.createElement("div");
         previewsRow.className = "mmxd-character-previews-row";
+        if (!refsOn) {
+          // kept, because switching the toolbar back must not cost the upload — but said
+          // out loud, because fl2va sends no reference images at all
+          previewsRow.style.opacity = "0.45";
+          previewsRow.title = "Not sent on the fl2va path. Switch to 'Refs ON (ref2va)' "
+                            + "to use this image; the description below is used either way.";
+        }
 
         data.images.forEach((imgData, imgIdx) => {
           const imgWrapper = document.createElement("div");
@@ -9893,11 +9919,31 @@ class TimelineEditor {
         }
 
         slot.appendChild(previewsRow);
+      } else {
+        // Still the drop target for the whole slot, but no longer the whole slot: it
+        // flexes so the text boxes below it keep their fixed height.
+        const zone = document.createElement("div");
+        zone.className = "mmxd-character-dropzone";
 
-        // Two captioned boxes: what the subject IS (the <Subject N> definition) and what
-        // has to survive into the target video (the retention_analysis line). They are
-        // different sentences in different sections of the prompt, so writing one has
-        // never been a way to say the other.
+        const label = document.createElement("div");
+        label.className = "mmxd-character-label";
+        label.textContent = `@ref${i + 1}`;
+
+        const placeholder = document.createElement("div");
+        placeholder.className = "mmxd-character-placeholder";
+        placeholder.innerHTML = `${ICONS.upload}<br>Drop Sheet`;
+
+        zone.appendChild(label);
+        zone.appendChild(placeholder);
+        slot.appendChild(zone);
+      }
+
+      {
+        // Captioned boxes, because two bare textareas in one box say nothing about which
+        // is which. Which ones appear is a question of what can reach the prompt:
+        // `retained` and the markers only exist once the slot has a picture to declare on
+        // the ref2va path, and `called` only matters where the subject has no <Subject N>
+        // label and lives in the prose instead.
         const makeSlotField = (label, key, placeholder, first) => {
           const field = document.createElement("div");
           field.className = "mmxd-character-field" + (first ? " mmxd-field-first" : "");
@@ -9927,46 +9973,55 @@ class TimelineEditor {
           return area;
         };
 
-        makeSlotField("describes", "description", "a woman in a red coat…", true);
-        makeSlotField("retained", "retentionNote",
-                      "identity, face and clothing — leave empty for the default");
+        const desc = makeSlotField("describes", "description",
+                                   "a woman in a red coat…", true);
+        // Typing does not redraw the panel — that would wipe the box mid-word — so a
+        // slot that has just been described claims its successor once focus leaves it.
+        desc.addEventListener("blur", () => {
+          if (this.characterSlots.length !== this.visibleSlotCount()) {
+            this.updateCharacterSlotsUI();
+          }
+        });
+
+        if (refsOn && hasImages) {
+          makeSlotField("retained", "retentionNote",
+                        "identity, face and clothing — leave empty for the default");
+        } else {
+          // No <Subject N> to name this by, so the guide's own habit applies: written out
+          // in full where it first appears, then a short handle, or the same paragraph
+          // of description walks in again every shot as somebody new.
+          makeSlotField("called", "shortName",
+                        "the baker — after the first mention");
+        }
 
         // What this subject IS, and how closely to follow it. The kind only supplies a
         // noun for the definition line when no description is typed, so a description
         // always wins; the retention marker is written into retention_analysis verbatim.
-        const row = document.createElement("div");
-        row.className = "mmxd-ref-controls";
+        // Both are ref2va-only, and both need a picture behind them to be declared on.
+        if (refsOn && hasImages) {
+          const row = document.createElement("div");
+          row.className = "mmxd-ref-controls";
 
-        const kindSel = createMenuSelect(SUBJECT_KIND_OPTIONS, { width: "100%" });
-        kindSel.value = data.kind || "person";
-        kindSel.title = "What this subject is. A typed description replaces it.";
-        kindSel.addEventListener("change", () => {
-          subjects[i].kind = kindSel.value;
-          this.commitChanges();
-        });
+          const kindSel = createMenuSelect(SUBJECT_KIND_OPTIONS, { width: "100%" });
+          kindSel.value = data.kind || "person";
+          kindSel.title = "What this subject is. A typed description replaces it.";
+          kindSel.addEventListener("change", () => {
+            subjects[i].kind = kindSel.value;
+            this.commitChanges();
+          });
 
-        const retSel = createMenuSelect(RETENTION_OPTIONS, { width: "100%" });
-        retSel.value = data.retention || "fully_preserved";
-        retSel.title = RETENTION_TIP;
-        retSel.addEventListener("change", () => {
-          subjects[i].retention = retSel.value;
-          this.commitChanges();
-        });
+          const retSel = createMenuSelect(RETENTION_OPTIONS, { width: "100%" });
+          retSel.value = data.retention || "fully_preserved";
+          retSel.title = RETENTION_TIP;
+          retSel.addEventListener("change", () => {
+            subjects[i].retention = retSel.value;
+            this.commitChanges();
+          });
 
-        row.appendChild(kindSel);
-        row.appendChild(retSel);
-        slot.appendChild(row);
-      } else {
-        const label = document.createElement("div");
-        label.className = "mmxd-character-label";
-        label.textContent = `@ref${i + 1}`;
-
-        const placeholder = document.createElement("div");
-        placeholder.className = "mmxd-character-placeholder";
-        placeholder.innerHTML = `${ICONS.upload}<br>Drop Sheet`;
-
-        slot.appendChild(label);
-        slot.appendChild(placeholder);
+          row.appendChild(kindSel);
+          row.appendChild(retSel);
+          slot.appendChild(row);
+        }
       }
     }
   }
@@ -10062,7 +10117,9 @@ class TimelineEditor {
       const out = [];
       for (let i = 0; i < slots.length && i < MAX_SUBJECT_SLOTS; i++) {
         const s = slots[i] || {};
-        if (!(s.images && s.images.length)) continue;
+        // a description with no image is a whole subject on the fl2va path, where the
+        // image would be discarded anyway — so an empty slot is one with neither
+        if (!(s.images && s.images.length) && !(s.description || "").trim()) continue;
         const desc = (s.description || "").trim();
         out.push({
           tag: `@ref${i + 1}`,
@@ -10309,6 +10366,7 @@ class TimelineEditor {
       subjects: this.subjectSlots().map(c => ({
         images: (c.images || []).map(img => img.b64 ? { b64: img.b64, name: img.name } : { name: img.name }),
         description: c.description || "",
+        shortName: c.shortName || "",
         kind: c.kind || "person",
         retention: c.retention || "fully_preserved",
         retentionNote: c.retentionNote || ""
@@ -11806,6 +11864,7 @@ class TimelineEditor {
         subjects: this.subjectSlots().map(c => ({
           images: (c.images || []).map(img => img.b64 ? { b64: img.b64, name: img.name } : { name: img.name }),
           description: c.description || "",
+          shortName: c.shortName || "",
           kind: c.kind || "person",
           retention: c.retention || "fully_preserved",
           retentionNote: c.retentionNote || ""

--- a/js/minimax_director.js
+++ b/js/minimax_director.js
@@ -38,6 +38,12 @@ const GLOBAL_PROP_MIN_H = GLOBAL_PROMPT_MIN_H + SOUND_ROW_HEIGHT;  // prompt box
 // The per-reference "describes / retained" strip in the segment properties panel, built
 // the same way. Hiding it with display:none gives the prompt box its height straight back.
 const REF_NOTE_ROW_HEIGHT = 66;
+// start / frames / size for a reference video. Reference frames are VAE-encoded whole and
+// their latents ride through every sampling step, so a long or large clip is the usual
+// cause of an out-of-memory render — and until now the only way to shorten one was to drag
+// its edge on the track, with nothing anywhere saying what it currently was.
+const REF_LIMITS_ROW_HEIGHT = 30;
+const REF_VIDEO_SIZES = [768, 640, 512, 384, 256];   // mirrors minimax_plan.REF_VIDEO_SIZES
 const PROP_MIN_H = 90;                                             // prompt box alone
 const MAX_THUMBNAIL_DIM = 512; // Increased to maintain quality for taller images
 
@@ -714,6 +720,13 @@ const STYLES = `
   /* same two-field shape as the sound strip, but a flex child of the properties panel
      rather than a strip docked inside the prompt box — see REF_NOTE_ROW_HEIGHT */
   .mmxd-ref-note-row { flex: 0 0 66px; width: 100%; display: flex; gap: 6px; padding: 4px 0 12px 0; box-sizing: border-box; }
+  /* start / frames / size for a reference video — the memory levers, see REF_LIMITS_ROW_HEIGHT */
+  .mmxd-ref-limits-row { flex: 0 0 30px; width: 100%; display: flex; align-items: center; gap: 10px; padding: 2px 0 4px 0; box-sizing: border-box; font-size: 10px; color: #8a8a8a; }
+  .mmxd-ref-limits-row label { display: inline-flex; align-items: center; gap: 4px; white-space: nowrap; }
+  .mmxd-ref-limits-row input { width: 58px; background: #111; color: #e0e0e0; border: 1px solid #333; border-radius: 3px; padding: 2px 4px; font-size: 10px; font-family: inherit; outline: none; box-sizing: border-box; }
+  .mmxd-ref-limits-row input:focus { border-color: #4fff8f; }
+  .mmxd-ref-limits-row .mmxd-msel { height: 20px; font-size: 10px; padding: 0 4px 0 6px; }
+  .mmxd-ref-limits-note { margin-left: auto; color: #5a5a5a; }
   .mmxd-sound-field { position: relative; flex: 1 1 0; min-width: 0; background: #1c1c1c; border: 1px solid #111; border-radius: 4px; box-sizing: border-box; }
   .mmxd-sound-field.focus-active { border-color: #888; }
   .mmxd-sound-label { position: absolute; top: 3px; left: 6px; font-size: 8px; font-weight: bold; color: #5a5a5a; text-transform: uppercase; letter-spacing: 0.5px; pointer-events: none; user-select: none; z-index: 5; }
@@ -3440,9 +3453,92 @@ class TimelineEditor {
     this.refNoteInput.addEventListener("input",
       () => writeRefText("refNote", this.refNoteInput.value));
 
+    // --- Reference video limits ------------------------------------------------------
+    // The two numbers that decide how much of a clip is encoded, and the resolution it is
+    // encoded at. They edit the segment's own trim and length rather than shadowing them,
+    // so the track keeps showing exactly what will be sent.
+    this.refLimitsRow = document.createElement("div");
+    this.refLimitsRow.className = "mmxd-ref-limits-row";
+    this.refLimitsRow.style.display = "none";
+
+    const limitField = (caption, title, onCommit) => {
+      const label = document.createElement("label");
+      label.textContent = caption;
+      label.title = title;
+      const input = document.createElement("input");
+      input.type = "number";
+      input.min = "0";
+      input.step = "1";
+      input.title = title;
+      const commit = () => {
+        const list = this.getSegmentArray(this.selectionType);
+        const target = list && list[this.selectedIndex];
+        if (!target) return;
+        onCommit(target, Math.max(0, Math.round(parseFloat(input.value) || 0)));
+        this.commitChanges(true);
+        this.render();
+        this.updateUIFromSelection();
+        if (this.node?._mmxRefreshPrompt) this.node._mmxRefreshPrompt();
+      };
+      input.addEventListener("change", commit);
+      input.addEventListener("blur", commit);
+      input.addEventListener("keydown", (e) => {
+        e.stopPropagation();                       // the canvas eats arrows and Delete
+        if (e.key === "Enter") input.blur();
+      });
+      label.appendChild(input);
+      this.refLimitsRow.appendChild(label);
+      return input;
+    };
+
+    this.refStartInput = limitField("start", "First frame taken from the source clip.",
+      (seg, value) => {
+        const source = seg.videoDurationFrames || 0;
+        seg.trimStart = source ? Math.min(value, Math.max(0, source - 1)) : value;
+        // never let the trim run past the end of the source
+        if (source) seg.length = Math.max(1, Math.min(seg.length, source - seg.trimStart));
+      });
+
+    this.refFramesInput = limitField("frames",
+      "How many frames are encoded. Fewer frames is less memory, and at 24 fps this is "
+      + "the clip's length in the video.",
+      (seg, value) => {
+        const source = seg.videoDurationFrames || 0;
+        let next = Math.max(1, value);
+        if (source) next = Math.min(next, Math.max(1, source - (seg.trimStart || 0)));
+        // stop short of the next clip on the track rather than overlapping it
+        const later = (this.timeline.motionSegments || [])
+          .filter(s => s.id !== seg.id && s.start > seg.start)
+          .sort((a, b) => a.start - b.start)[0];
+        if (later) next = Math.min(next, Math.max(1, later.start - seg.start));
+        seg.length = next;
+      });
+
+    this.refSizeSelect = createMenuSelect(
+      REF_VIDEO_SIZES.map(v => ({ value: String(v), label: `${v}px` })), { width: "76px" });
+    this.refSizeSelect.title =
+      "Short edge the clip is decoded at. Memory goes with the square of this, so it is "
+      + "the biggest lever on an out-of-memory render — 384 is about a quarter of 768.";
+    this.refSizeSelect.addEventListener("change", () => {
+      const list = this.getSegmentArray(this.selectionType);
+      const target = list && list[this.selectedIndex];
+      if (!target) return;
+      target.refSize = parseInt(this.refSizeSelect.value, 10);
+      this.commitChanges(true);
+    });
+    const sizeLabel = document.createElement("label");
+    sizeLabel.textContent = "size";
+    sizeLabel.appendChild(this.refSizeSelect);
+    this.refLimitsRow.appendChild(sizeLabel);
+
+    this.refLimitsNote = document.createElement("span");
+    this.refLimitsNote.className = "mmxd-ref-limits-note";
+    this.refLimitsRow.appendChild(this.refLimitsNote);
+
     propContainer.appendChild(this.promptWrapper);
     propContainer.appendChild(this.motionInfoArea);
     propContainer.appendChild(this.audioInfoArea);
+    propContainer.appendChild(this.refLimitsRow);
     propContainer.appendChild(this.refNoteRow);
     propContainer.appendChild(propResizer);
 
@@ -5884,8 +5980,37 @@ class TimelineEditor {
   // The properties panel has to hold the prompt box *and*, when a reference is selected,
   // the note strip. Without this the default 90px panel would leave the prompt box 24px.
   _propMinH() {
-    const showing = this.refNoteRow && this.refNoteRow.style.display !== "none";
-    return PROP_MIN_H + (showing ? REF_NOTE_ROW_HEIGHT : 0);
+    const notes = this.refNoteRow && this.refNoteRow.style.display !== "none";
+    const limits = this.refLimitsRow && this.refLimitsRow.style.display !== "none";
+    return PROP_MIN_H + (notes ? REF_NOTE_ROW_HEIGHT : 0)
+                      + (limits ? REF_LIMITS_ROW_HEIGHT : 0);
+  }
+
+  // The reference-video limits, shown only for a clip on the reference-video track.
+  // Frames and start edit the segment itself, so the track keeps showing what will be sent.
+  _syncRefLimitsRow(seg) {
+    if (!this.refLimitsRow) return;
+    const refsOn = String(this.timeline.reference_mode || "OFF").toUpperCase() !== "OFF";
+    if (!seg || this.selectionType !== "motion" || !refsOn || this.retakeMode) {
+      this.refLimitsRow.style.display = "none";
+      return;
+    }
+    this.refLimitsRow.style.display = "flex";
+
+    const fps = this.getFrameRate() || 24;
+    const frames = Math.max(1, Math.round(seg.length || 1));
+    this.refStartInput.value = Math.max(0, Math.round(seg.trimStart || 0));
+    this.refFramesInput.value = frames;
+    this.refSizeSelect.value = String(seg.refSize || REF_VIDEO_SIZES[0]);
+
+    // What this clip actually costs, in the terms that matter: seconds against the model
+    // card's 2-15s window, and whether it is the one blowing the memory budget.
+    const secs = frames / fps;
+    const parts = [`${secs.toFixed(1)}s`];
+    if (secs < 2) parts.push("under the 2s minimum");
+    else if (secs > 15) parts.push("over the 15s maximum");
+    this.refLimitsNote.textContent = parts.join(" · ");
+    this.refLimitsNote.style.color = (secs < 2 || secs > 15) ? "#d08a3a" : "#5a5a5a";
   }
 
   // Opens the panel far enough that showing the strip does not squeeze the prompt box to
@@ -5984,8 +6109,9 @@ class TimelineEditor {
       if (this.segmentBoundsDisplay) {
         this.segmentBoundsDisplay.textContent = "Multiple Segments Selected";
       }
-      // there is no single reference to annotate, and leaving the strip up would show
-      // the previously selected segment's text as if it belonged to this selection
+      // there is no single reference to annotate, and leaving these up would show the
+      // previously selected segment's values as if they belonged to this selection
+      this._syncRefLimitsRow(null);
       this._syncRefNoteRow(null);
       return;
     }
@@ -6034,8 +6160,9 @@ class TimelineEditor {
       this.promptInput.style.opacity = "";
     }
 
-    // Set once here rather than in each branch below: the strip belongs to the selected
+    // Set once here rather than in each branch below: these belong to the selected
     // segment, not to whichever of the prompt box / motion info / audio info is on show.
+    this._syncRefLimitsRow(seg);
     this._syncRefNoteRow(seg);
 
     if (this.retakeMode) {

--- a/js/minimax_director.js
+++ b/js/minimax_director.js
@@ -646,9 +646,10 @@ const STYLES = `
     border-top: 1px solid #333;
     margin: 4px 0;
   }
-  /* --- Character reference slots --- */
-  .mmxd-characters-container { display: flex; justify-content: space-between; gap: 12px; margin-top: 6px; margin-bottom: 4px; box-sizing: border-box; width: 100%; flex-shrink: 0; }
-  .mmxd-character-slot { flex: 1; background: #1e1e1e; border: 1.5px dashed #444; border-radius: 8px; height: 120px; display: flex; flex-direction: column; align-items: center; justify-content: flex-start; padding: 4px; position: relative; cursor: pointer; overflow: hidden; transition: all 0.2s ease; box-sizing: border-box; }
+  /* --- Subject reference slots --- */
+  .mmxd-characters-container { display: flex; flex-wrap: wrap; justify-content: flex-start; gap: 12px; margin-top: 6px; margin-bottom: 4px; box-sizing: border-box; width: 100%; flex-shrink: 0; }
+  /* grows to nine slots, so they wrap into rows of three rather than shrinking to slivers */
+  .mmxd-character-slot { flex: 1 1 calc(33.333% - 8px); min-width: 120px; background: #1e1e1e; border: 1.5px dashed #444; border-radius: 8px; height: 148px; display: flex; flex-direction: column; align-items: center; justify-content: flex-start; padding: 4px; position: relative; cursor: pointer; overflow: hidden; transition: all 0.2s ease; box-sizing: border-box; }
   .mmxd-character-slot:hover { border-color: #666; background: #252525; }
   .mmxd-character-slot.drag-over { border-color: #4fff8f; background: rgba(79, 255, 143, 0.05); }
   .mmxd-character-label { font-size: 10px; font-weight: bold; color: #888; margin-bottom: 2px; pointer-events: none; }
@@ -663,7 +664,11 @@ const STYLES = `
   .mmxd-character-validate-btn.loading { background: #333; color: #888; cursor: wait; pointer-events: none; }
   .mmxd-character-desc { width: 100%; height: 38px; background: #111; color: #e0e0e0; border: 1px solid #333; border-radius: 4px; font-size: 9px; resize: none; box-sizing: border-box; padding: 2px 4px; margin-top: 10px; outline: none; font-family: inherit; z-index: 10; }
   .mmxd-character-desc:focus { border-color: #4fff8f; }
-  /* --- @char autocomplete popup --- */
+  /* --- per-reference kind / retention controls --- */
+  .mmxd-ref-controls { display: flex; gap: 4px; width: 100%; margin-top: 4px; box-sizing: border-box; }
+  .mmxd-ref-controls .mmxd-msel { flex: 1 1 0; min-width: 0; height: 20px; font-size: 9px; padding: 0 4px 0 6px; }
+  .mmxd-ref-controls .mmxd-msel-caret svg { width: 8px; height: 8px; }
+  /* --- @refN autocomplete popup --- */
   .mmxd-autocomplete-menu { position: fixed; background: #181818; border: 1px solid #444; border-radius: 6px; padding: 4px; display: flex; flex-direction: column; gap: 2px; z-index: 100000; box-shadow: 0 4px 16px rgba(0,0,0,0.6); min-width: 180px; max-height: 200px; overflow-y: auto; }
   .mmxd-autocomplete-item { background: #252525; color: #aaa; border: 1px solid #333; border-radius: 4px; padding: 6px 12px; font-size: 11px; font-family: monospace; cursor: pointer; text-align: left; display: flex; align-items: center; justify-content: space-between; transition: all 0.15s ease; }
   .mmxd-autocomplete-item:hover, .mmxd-autocomplete-item.active { background: #1c222d; color: #4fff8f; border-color: #4fff8f; }
@@ -791,6 +796,99 @@ function createMenuSelect(options, opts) {
 }
 
 
+// --- Full-reference vocabulary ------------------------------------------------------
+// Mirrors minimax_plan.py, which mirrors the H3 reference guide
+// (skills/h3-prompt-writing/references/ref-en.txt). The retention markers are shown by
+// their own names rather than friendlier ones: the guide calls them "fixed English values
+// in the output format", they are written into the prompt verbatim, and a prettier label
+// would hide which of them you actually picked.
+const MAX_SUBJECT_SLOTS = 9;
+
+const SUBJECT_KIND_OPTIONS = [
+  { value: "person", label: "person" },
+  { value: "animal", label: "animal" },
+  { value: "object", label: "object" },
+  { value: "environment", label: "environment" },
+  { value: "clothing", label: "clothing" },
+  { value: "prop", label: "prop" },
+  { value: "interface", label: "interface" },
+  { value: "effect", label: "visual effect" },
+  { value: "style", label: "style" },
+  { value: "action", label: "action" },
+  { value: "expression", label: "expression" },
+  { value: "pose", label: "pose" },
+];
+
+const RETENTION_OPTIONS = [
+  { value: "fully_preserved", label: "fully_preserved" },
+  { value: "partially_preserved", label: "partially_preserved" },
+  { value: "attribute_transfer", label: "attribute_transfer" },
+  { value: "weak_reference", label: "weak_reference" },
+];
+
+const RETENTION_AUDIO_OPTIONS = [
+  { value: "reference", label: "reference" },
+  { value: "fully_copy", label: "fully_copy" },
+  { value: "partially_copy", label: "partially_copy" },
+  { value: "weak_reference", label: "weak_reference" },
+];
+
+const REF_ROLE_OPTIONS = [
+  { value: "auto", label: "frame anchor" },
+  { value: "storyboard", label: "storyboard" },
+  { value: "subject", label: "defines a subject" },
+];
+
+const RETENTION_TIP =
+  "How closely the model follows this reference (guide 4.1):\n" +
+  "fully_preserved — keep it as defined\n" +
+  "partially_preserved — keep it, but some defined traits change\n" +
+  "attribute_transfer — move its traits onto a different subject\n" +
+  "weak_reference — broad similarity only";
+
+const RETENTION_AUDIO_TIP =
+  "How the reference audio is used (guide 4.2):\n" +
+  "reference — follow its timbre or style, do not copy the signal\n" +
+  "fully_copy — reuse it as the complete final audio track\n" +
+  "partially_copy — copy part of it, add or replace the rest\n" +
+  "weak_reference — broad similarity in category or atmosphere only";
+
+const REF_ROLE_TIP =
+  "What this image is for (guide 2.2):\n" +
+  "frame anchor — it IS a first/last frame or keyframe of its shot\n" +
+  "storyboard — it plans the shot's viewpoint and staging\n" +
+  "defines a subject — it only defines a look, so it gets no <Picture> entry";
+
+// Slots wrap three to a row; the node has to reserve the rows or it crops the last one.
+const SUBJECT_SLOT_H = 148, SUBJECT_SLOT_GAP = 12;
+function subjectPanelHeight(slotCount) {
+  const rows = Math.max(1, Math.ceil(slotCount / 3));
+  return rows * SUBJECT_SLOT_H + (rows - 1) * SUBJECT_SLOT_GAP + 20;
+}
+
+function emptySubjectSlot() {
+  return { images: [], description: "", kind: "person", retention: "fully_preserved",
+           retentionNote: "" };
+}
+
+// Old timelines wrote `characters` and had neither kind nor retention. Reading them back
+// with today's defaults reproduces the old wording exactly, so nothing silently changes
+// meaning under an existing workflow.
+function normaliseSubjectSlots(raw) {
+  const list = Array.isArray(raw) ? raw : [];
+  const out = list.slice(0, MAX_SUBJECT_SLOTS).map((c) => ({
+    images: Array.isArray(c.images) ? c.images : [],
+    description: c.description || "",
+    kind: SUBJECT_KIND_OPTIONS.some(o => o.value === c.kind) ? c.kind : "person",
+    retention: RETENTION_OPTIONS.some(o => o.value === c.retention)
+      ? c.retention : "fully_preserved",
+    retentionNote: c.retentionNote || "",
+  }));
+  while (out.length < 3) out.push(emptySubjectSlot());
+  return out;
+}
+
+
 // --- Icons ---
 const ICONS = {
   upload: `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="17 8 12 3 7 8"></polyline><line x1="12" y1="3" x2="12" y2="15"></line></svg>`,
@@ -846,11 +944,9 @@ function parseInitial(jsonStr) {
     analyzeProvider: "ollama",
     analyzeBaseUrl: "",
     analyzeModel: "",
-    characters: [
-      { images: [], description: "" },
-      { images: [], description: "" },
-      { images: [], description: "" }
-    ]
+    summary: "",
+    task_type_override: "",
+    subjects: normaliseSubjectSlots(null)
   };
   try {
     if (jsonStr) {
@@ -884,14 +980,15 @@ function parseInitial(jsonStr) {
       if (p.analyzeProvider !== undefined) parsed.analyzeProvider = p.analyzeProvider;
       if (p.analyzeBaseUrl !== undefined) parsed.analyzeBaseUrl = p.analyzeBaseUrl;
       if (p.analyzeModel !== undefined) parsed.analyzeModel = p.analyzeModel;
-      if (Array.isArray(p.characters)) {
-        parsed.characters = p.characters.map(c => ({
-          images: Array.isArray(c.images) ? c.images : [],
-          description: c.description || ""
-        }));
-        while (parsed.characters.length < 3) {
-          parsed.characters.push({ images: [], description: "" });
-        }
+      if (p.summary !== undefined) parsed.summary = p.summary || "";
+      if (p.task_type_override !== undefined) {
+        parsed.task_type_override = p.task_type_override || "";
+      }
+      // `subjects` is the current key; `characters` is the same panel's old one. A
+      // timeline saved before subject kinds existed reads back with today's defaults,
+      // which reproduce the wording it was written against.
+      if (Array.isArray(p.subjects) || Array.isArray(p.characters)) {
+        parsed.subjects = normaliseSubjectSlots(p.subjects || p.characters);
       }
       if (Array.isArray(p.segments)) {
         parsed.segments = p.segments.map(s => {
@@ -3062,6 +3159,12 @@ class TimelineEditor {
     this.musicInput = makeSoundField(
       "non_diegetic_music", "non_diegetic_music",
       "Score only the audience hears. Name instrumentation, tempo and dynamics, or write N/A.");
+    // The reference guide's own section, and the one place the [task type] prefix can
+    // hang. Same field pattern as the two above for the same reason: one value, read by
+    // both the node and the live preview, with no second copy to fall out of step.
+    this.summaryInput = makeSoundField(
+      "summary", "summary",
+      "One paragraph on the target video and what each reference is for. The [task type] prefix is added for you.");
     globalPromptWrapper.appendChild(soundRow);
 
     this.globalPromptInput.addEventListener("input", (e) => {
@@ -4024,10 +4127,10 @@ class TimelineEditor {
     this.wrapper.appendChild(propContainer);
     this.wrapper.appendChild(this.globalPropContainer);
 
-    // --- Character reference slots (3 @char panels) at the bottom of the editor ---
+    // --- Subject reference slots (@refN panels) at the bottom of the editor ---
     this.createCharacterSlots(this.wrapper);
 
-    // --- @char autocomplete on both prompt fields ---
+    // --- @refN autocomplete on both prompt fields ---
     if (this.globalPromptInput) this.setupAutocomplete(this.globalPromptInput);
     if (this.promptInput) this.setupAutocomplete(this.promptInput);
 
@@ -9170,67 +9273,115 @@ class TimelineEditor {
 
   // --- Backend Data Sync ---
   // --- Visual Character Reference Slots ---
+  // The slots hold <Subject N> definitions, which the guide says may be "people, animals,
+  // or objects; scenes, backgrounds, or environments; clothing, props, interfaces, or
+  // visual effects; styles, actions, expressions, or poses" — not only characters. The
+  // class names still say "character" because they are shared with a lot of CSS and with
+  // the LTX editor this was forked from; the data key is `subjects`.
+  subjectSlots() {
+    if (!Array.isArray(this.timeline.subjects)) {
+      this.timeline.subjects = normaliseSubjectSlots(
+        this.timeline.subjects || this.timeline.characters);
+    }
+    return this.timeline.subjects;
+  }
+
+  // Three always visible, then one empty slot ahead of whatever is filled, so the panel
+  // grows only as far as it is used instead of showing nine empty boxes on day one.
+  visibleSlotCount() {
+    const slots = this.subjectSlots();
+    let filled = 0;
+    slots.forEach((s, i) => { if (s.images && s.images.length) filled = i + 1; });
+    return Math.max(3, Math.min(MAX_SUBJECT_SLOTS, filled + 1));
+  }
+
+  _buildSubjectSlotEl(i) {
+    const slot = document.createElement("div");
+    slot.className = "mmxd-character-slot";
+    slot.dataset.index = i;
+
+    slot.addEventListener("dragover", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      slot.classList.add("drag-over");
+    });
+    slot.addEventListener("dragleave", (e) => {
+      e.stopPropagation();
+      slot.classList.remove("drag-over");
+    });
+    slot.addEventListener("drop", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      slot.classList.remove("drag-over");
+      if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
+        Array.from(e.dataTransfer.files).forEach(f => this.handleCharacterImageUpload(f, i));
+      }
+    });
+    slot.addEventListener("click", (e) => {
+      if (e.target.closest(".mmxd-character-delete") ||
+          e.target.closest(".mmxd-character-validate-btn") ||
+          e.target.closest(".mmxd-character-desc") ||
+          e.target.closest(".mmxd-msel")) return;
+
+      const fi = document.createElement("input");
+      fi.type = "file";
+      fi.accept = "image/*";
+      fi.multiple = true;
+      fi.addEventListener("change", (ev) => {
+        if (ev.target.files) {
+          Array.from(ev.target.files).forEach(f => this.handleCharacterImageUpload(f, i));
+        }
+      });
+      fi.click();
+    });
+    return slot;
+  }
+
   createCharacterSlots(parent) {
     const container = document.createElement("div");
     container.className = "mmxd-characters-container";
 
-    if (!this.timeline.characters) {
-      this.timeline.characters = [
-        { images: [], description: "" },
-        { images: [], description: "" },
-        { images: [], description: "" }
-      ];
-    }
-
+    this.subjectSlots();
     this.characterSlots = [];
-
-    for (let i = 0; i < 3; i++) {
-      const slot = document.createElement("div");
-      slot.className = "mmxd-character-slot";
-      slot.dataset.index = i;
-
-      slot.addEventListener("dragover", (e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        slot.classList.add("drag-over");
-      });
-      slot.addEventListener("dragleave", (e) => {
-        e.stopPropagation();
-        slot.classList.remove("drag-over");
-      });
-      slot.addEventListener("drop", (e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        slot.classList.remove("drag-over");
-        if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
-          Array.from(e.dataTransfer.files).forEach(f => this.handleCharacterImageUpload(f, i));
-        }
-      });
-      slot.addEventListener("click", (e) => {
-        if (e.target.closest(".mmxd-character-delete") ||
-            e.target.closest(".mmxd-character-validate-btn") ||
-            e.target.closest(".mmxd-character-desc")) return;
-
-        const fi = document.createElement("input");
-        fi.type = "file";
-        fi.accept = "image/*";
-        fi.multiple = true;
-        fi.addEventListener("change", (ev) => {
-          if (ev.target.files) {
-            Array.from(ev.target.files).forEach(f => this.handleCharacterImageUpload(f, i));
-          }
-        });
-        fi.click();
-      });
-
-      container.appendChild(slot);
-      this.characterSlots.push(slot);
-    }
 
     parent.appendChild(container);
     this.charPanelContainer = container;
-    this.charPanelHeight = 150;
+    this.charPanelHeight = subjectPanelHeight(3);
     this.updateCharacterSlotsUI();
+  }
+
+  // Adds or removes slot elements so the DOM matches visibleSlotCount(). Called from
+  // updateCharacterSlotsUI, which is the only entry point that redraws the panel.
+  _syncSubjectSlotEls() {
+    const container = this.charPanelContainer;
+    if (!container) return;
+    const want = this.visibleSlotCount();
+    const slots = this.subjectSlots();
+    while (slots.length < want) slots.push(emptySubjectSlot());
+    while (this.characterSlots.length < want) {
+      const el = this._buildSubjectSlotEl(this.characterSlots.length);
+      container.appendChild(el);
+      this.characterSlots.push(el);
+    }
+    while (this.characterSlots.length > want) {
+      this.characterSlots.pop().remove();
+    }
+
+    // Slots wrap three to a row, so the panel's reserved height has to follow the row
+    // count or the node crops the last row the moment a fourth subject is added.
+    const height = subjectPanelHeight(want);
+    const grew = height !== this.charPanelHeight;
+    this.charPanelHeight = height;
+    // Only once the panel has been through a full build: during construction the widget's
+    // computeSize is not installed yet, so resizing here would size the node against a
+    // panel height it does not know about — and would fight the size a saved workflow
+    // restored. After that, this fires whenever a slot is gained or lost.
+    if (grew && this._subjectPanelReady && this.node?.setDirtyCanvas
+        && typeof this.node.computeSize === "function" && this.node.size) {
+      this.node.setSize([this.node.size[0], this.node.computeSize()[1]]);
+      this.node.setDirtyCanvas(true, true);
+    }
+    this._subjectPanelReady = true;
   }
 
   handleCharacterImageUpload(file, idx) {
@@ -9276,13 +9427,11 @@ class TimelineEditor {
           stored = { b64: canvas.toDataURL("image/jpeg", 0.95), name: file.name };
         }
 
-        if (!this.timeline.characters[idx].images) {
-          this.timeline.characters[idx].images = [];
-        }
-        if (this.timeline.characters[idx].images.length >= 2) {
-          this.timeline.characters[idx].images.shift();
-        }
-        this.timeline.characters[idx].images.push(stored);
+        const subjects = this.subjectSlots();
+        while (subjects.length <= idx) subjects.push(emptySubjectSlot());
+        if (!subjects[idx].images) subjects[idx].images = [];
+        if (subjects[idx].images.length >= 2) subjects[idx].images.shift();
+        subjects[idx].images.push(stored);
         this.updateCharacterSlotsUI();
         this.commitChanges();
       };
@@ -9324,17 +9473,12 @@ class TimelineEditor {
 
   updateCharacterSlotsUI() {
     if (!this.characterSlots) return;
-    if (!this.timeline.characters) {
-      this.timeline.characters = [
-        { images: [], description: "" },
-        { images: [], description: "" },
-        { images: [], description: "" }
-      ];
-    }
+    const subjects = this.subjectSlots();
+    this._syncSubjectSlotEls();
 
-    for (let i = 0; i < 3; i++) {
+    for (let i = 0; i < this.characterSlots.length; i++) {
       const slot = this.characterSlots[i];
-      const data = this.timeline.characters[i] || { images: [], description: "" };
+      const data = subjects[i] || emptySubjectSlot();
       slot.innerHTML = "";
 
       if (data.images && data.images.length > 0) {
@@ -9356,8 +9500,8 @@ class TimelineEditor {
           delBtn.title = "Delete Image";
           delBtn.addEventListener("click", (e) => {
             e.stopPropagation();
-            if (this.timeline.characters[i] && this.timeline.characters[i].images) {
-              this.timeline.characters[i].images.splice(imgIdx, 1);
+            if (subjects[i] && subjects[i].images) {
+              subjects[i].images.splice(imgIdx, 1);
               this.updateCharacterSlotsUI();
               this.commitChanges();
             }
@@ -9388,15 +9532,41 @@ class TimelineEditor {
         descInput.value = data.description || "";
         descInput.placeholder = "manual description...";
         descInput.addEventListener("input", () => {
-          this.timeline.characters[i].description = descInput.value;
+          subjects[i].description = descInput.value;
           this.commitChanges();
         });
         descInput.addEventListener("click", (e) => { e.stopPropagation(); });
         slot.appendChild(descInput);
+
+        // What this subject IS, and how closely to follow it. The kind only supplies a
+        // noun for the definition line when no description is typed, so a description
+        // always wins; the retention marker is written into retention_analysis verbatim.
+        const row = document.createElement("div");
+        row.className = "mmxd-ref-controls";
+
+        const kindSel = createMenuSelect(SUBJECT_KIND_OPTIONS, { width: "100%" });
+        kindSel.value = data.kind || "person";
+        kindSel.title = "What this subject is. A typed description replaces it.";
+        kindSel.addEventListener("change", () => {
+          subjects[i].kind = kindSel.value;
+          this.commitChanges();
+        });
+
+        const retSel = createMenuSelect(RETENTION_OPTIONS, { width: "100%" });
+        retSel.value = data.retention || "fully_preserved";
+        retSel.title = RETENTION_TIP;
+        retSel.addEventListener("change", () => {
+          subjects[i].retention = retSel.value;
+          this.commitChanges();
+        });
+
+        row.appendChild(kindSel);
+        row.appendChild(retSel);
+        slot.appendChild(row);
       } else {
         const label = document.createElement("div");
         label.className = "mmxd-character-label";
-        label.textContent = `@char${i + 1}`;
+        label.textContent = `@ref${i + 1}`;
 
         const placeholder = document.createElement("div");
         placeholder.className = "mmxd-character-placeholder";
@@ -9437,7 +9607,7 @@ class TimelineEditor {
     }
 
     const b64_images = (await Promise.all(
-      (this.timeline.characters[idx].images || []).map(img => this._refImageToB64(img))
+      (this.subjectSlots()[idx].images || []).map(img => this._refImageToB64(img))
     )).filter(Boolean);
 
     try {
@@ -9454,7 +9624,7 @@ class TimelineEditor {
       });
       const result = await resp.json();
       if (result.status === "success") {
-        this.timeline.characters[idx].description = result.description;
+        this.subjectSlots()[idx].description = result.description;
         btn.textContent = "Success!";
         setTimeout(() => { this.updateCharacterSlotsUI(); this.commitChanges(); }, 1500);
       } else {
@@ -9470,7 +9640,7 @@ class TimelineEditor {
     }
   }
 
-  // --- @char auto-complete popup (attaches to a given textarea) ---
+  // --- @refN auto-complete popup (attaches to a given textarea) ---
   setupAutocomplete(input) {
     if (!input || input._prAutocompleteAttached) return;
     input._prAutocompleteAttached = true;
@@ -9482,11 +9652,31 @@ class TimelineEditor {
     if (!this._autocompleteMenus) this._autocompleteMenus = [];
     this._autocompleteMenus.push(menu);
 
-    const suggestions = [
-      { tag: "@char1", label: "Character 1" },
-      { tag: "@char2", label: "Character 2" },
-      { tag: "@char3", label: "Character 3" }
-    ];
+    // One entry per slot that has something in it, labelled with its description so a
+    // panel of nine is still navigable. @char1..@char3 stay valid in typed prompts — the
+    // planner accepts both spellings — but only @refN is offered, since a slot is no
+    // longer necessarily a character.
+    const buildSuggestions = () => {
+      const slots = this.subjectSlots();
+      const out = [];
+      for (let i = 0; i < slots.length && i < MAX_SUBJECT_SLOTS; i++) {
+        const s = slots[i] || {};
+        if (!(s.images && s.images.length)) continue;
+        const desc = (s.description || "").trim();
+        out.push({
+          tag: `@ref${i + 1}`,
+          label: desc ? (desc.length > 40 ? desc.slice(0, 40) + "…" : desc)
+                      : (s.kind || "person"),
+        });
+      }
+      // nothing dropped yet: still offer the three that always exist, so the tag is
+      // discoverable before the panel is filled
+      if (!out.length) {
+        for (let i = 0; i < 3; i++) out.push({ tag: `@ref${i + 1}`, label: `slot ${i + 1}` });
+      }
+      return out;
+    };
+    let suggestions = buildSuggestions();
 
     let activeIndex = 0;
     let showMenu = false;
@@ -9505,6 +9695,9 @@ class TimelineEditor {
       const cursor = input.selectionStart;
       const query = text.slice(queryStart + 1, cursor).toLowerCase();
 
+      // rebuilt each time the menu is drawn: slots are added and described while the
+      // editor is open, and a stale list would offer tags that no longer resolve
+      suggestions = buildSuggestions();
       const filtered = suggestions.filter(s => s.tag.toLowerCase().includes("@" + query) || s.tag.toLowerCase().includes(query));
       if (filtered.length === 0) { hideMenu(); return; }
 
@@ -9729,9 +9922,14 @@ class TimelineEditor {
       analyzeProvider: this.timeline.analyzeProvider || "ollama",
       analyzeBaseUrl: this.timeline.analyzeBaseUrl || "",
       analyzeModel: this.timeline.analyzeModel || "",
-      characters: (this.timeline.characters || []).map(c => ({
+      summary: this.timeline.summary || "",
+      task_type_override: this.timeline.task_type_override || "",
+      subjects: this.subjectSlots().map(c => ({
         images: (c.images || []).map(img => img.b64 ? { b64: img.b64, name: img.name } : { name: img.name }),
-        description: c.description || ""
+        description: c.description || "",
+        kind: c.kind || "person",
+        retention: c.retention || "fully_preserved",
+        retentionNote: c.retentionNote || ""
       })),
       segments: sortedSegments.map(s => {
         const { imgObj, videoEl, _isSeeking, thumbnails, _extractingThumbs, _sSecs, _lSecs, _tSecs, _dSecs, _uploading, _blobUrl, ...rest } = s;
@@ -10533,6 +10731,58 @@ class TimelineEditor {
     };
 
     // ==========================================
+    // 5b. Reference role and retention (ref2va only — the fl2va path has no labels to
+    // attach any of this to, so showing it there would offer a setting with no effect)
+    // ==========================================
+    const refBtns = [];
+    if (String(this.timeline.reference_mode || "OFF").toUpperCase() !== "OFF") {
+      let onRefChange = () => {};
+      const cycler = (caption, options, key, fallback, tip) => {
+        const btn = document.createElement("button");
+        btn.className = "mmxd-gap-menu-btn";
+        const draw = () => {
+          const cur = options.find(o => o.value === seg[key]) || options[0];
+          btn.innerHTML = `${caption}: <b style="color:#4fff8f">${cur.label}</b>`;
+        };
+        btn.title = tip;
+        btn.onclick = (e) => {
+          e.stopPropagation();
+          const at = Math.max(0, options.findIndex(o => o.value === (seg[key] || fallback)));
+          seg[key] = options[(at + 1) % options.length].value;
+          draw();
+          onRefChange();
+          this.commitChanges();
+          this.render();
+          if (this.node?._mmxRefreshPrompt) this.node._mmxRefreshPrompt();
+        };
+        draw();
+        return btn;
+      };
+      if (trackType === "image" && (seg.type === "image" || seg.type === "video")) {
+        refBtns.push(cycler("Used as", REF_ROLE_OPTIONS, "refRole", "auto", REF_ROLE_TIP));
+        // Only meaningful once the image defines something rather than anchoring a frame:
+        // it picks the noun the <Subject N> line uses. Built either way and shown on
+        // demand, so cycling the role reveals it without reopening the menu. A slot in
+        // the panel above is the place for a subject that needs a written description.
+        const kindBtn = cycler("Defines a", SUBJECT_KIND_OPTIONS, "refKind", "person",
+                               "What this image defines, for its <Subject N> line.");
+        onRefChange = () => {
+          kindBtn.style.display = seg.refRole === "subject" ? "" : "none";
+        };
+        onRefChange();
+        refBtns.push(kindBtn);
+        refBtns.push(cycler("Follow it", RETENTION_OPTIONS, "retention",
+                            "fully_preserved", RETENTION_TIP));
+      } else if (trackType === "motion") {
+        refBtns.push(cycler("Follow it", RETENTION_OPTIONS, "retention",
+                            "fully_preserved", RETENTION_TIP));
+      } else if (trackType === "audio") {
+        refBtns.push(cycler("Follow it", RETENTION_AUDIO_OPTIONS, "retention",
+                            "reference", RETENTION_AUDIO_TIP));
+      }
+    }
+
+    // ==========================================
     // 6. Define Delete Option
     // ==========================================
     const delBtn = document.createElement("button");
@@ -10585,6 +10835,12 @@ class TimelineEditor {
     // Group 4: Convert to End Frame (Only if toggleEndFrameBtn is defined)
     if (toggleEndFrameBtn) {
       menu.appendChild(toggleEndFrameBtn);
+      menu.appendChild(makeDivider());
+    }
+
+    // Group 5a: what this reference is for, and how closely to follow it
+    if (refBtns.length) {
+      refBtns.forEach(b => menu.appendChild(b));
       menu.appendChild(makeDivider());
     }
 
@@ -11227,9 +11483,14 @@ class TimelineEditor {
         analyzeProvider: this.timeline.analyzeProvider || "ollama",
         analyzeBaseUrl: this.timeline.analyzeBaseUrl || "",
         analyzeModel: this.timeline.analyzeModel || "",
-        characters: (this.timeline.characters || []).map(c => ({
+        summary: this.timeline.summary || "",
+        task_type_override: this.timeline.task_type_override || "",
+        subjects: this.subjectSlots().map(c => ({
           images: (c.images || []).map(img => img.b64 ? { b64: img.b64, name: img.name } : { name: img.name }),
-          description: c.description || ""
+          description: c.description || "",
+          kind: c.kind || "person",
+          retention: c.retention || "fully_preserved",
+          retentionNote: c.retentionNote || ""
         })),
         segments: (this.timeline.segments || []).map(s => {
           const { imgObj, videoEl, _isSeeking, thumbnails, _extractingThumbs, _sSecs, _lSecs, _tSecs, _dSecs, _uploading, _blobUrl, ...rest } = s;
@@ -11594,6 +11855,27 @@ class TimelineEditor {
     fmtCtrl.appendChild(fmtCuSeg);
 
     menu.appendChild(this._makeSettingRow("Prompt Format", fmtCtrl));
+
+    // The [task type] prefix on `summary` is derived from what the references are
+    // actually used for. This is the escape hatch for the two the timeline cannot know —
+    // `video editing` and `video continuation`, which need a source video this node has
+    // no path to edit or continue.
+    const taskInput = document.createElement("input");
+    taskInput.type = "text";
+    taskInput.className = "mmxd-settings-input";
+    taskInput.placeholder = "auto — e.g. video continuation + keyframe completion";
+    taskInput.value = this.timeline.task_type_override || "";
+    taskInput.title =
+      "Overrides the square-bracketed task type on the summary line.\n" +
+      "Leave empty to derive it from the references in use.\n" +
+      "Guide values: keyframe completion, reference generation, video editing,\n" +
+      "video continuation, audio reuse, audio reference — joined with ' + '.";
+    taskInput.addEventListener("input", () => {
+      this.timeline.task_type_override = taskInput.value;
+      this.commitChanges(true);
+      if (this.node._mmxRefreshPrompt) this.node._mmxRefreshPrompt();
+    });
+    menu.appendChild(this._makeSettingRow("Task Type", taskInput));
 
     const divider2 = document.createElement("div");
     divider2.className = "mmxd-settings-divider";
@@ -12808,9 +13090,9 @@ app.registerExtension({
           const canvasH = self._timelineEditor ? self._timelineEditor.canvasHeight : CANVAS_HEIGHT;
           const propH = self._timelineEditor ? (self._timelineEditor.propHeight || 90) : 90;
           const globalPropH = self._timelineEditor ? (self._timelineEditor.globalPropHeight || 60) : 60;
-          // Reserve room for the @char reference panel at the bottom so the node doesn't
+          // Reserve room for the @refN reference panel at the bottom so the node doesn't
           // collapse and crop it whenever ComfyUI recomputes the node height.
-          const charPanelH = self._timelineEditor ? (self._timelineEditor.charPanelHeight || 150) : 150;
+          const charPanelH = self._timelineEditor ? (self._timelineEditor.charPanelHeight || subjectPanelHeight(3)) : subjectPanelHeight(3);
           const nodeWidth = self.size?.[0] || width || 1375;
           return [Math.max(10, nodeWidth - 30), canvasH + propH + globalPropH + charPanelH + 160];
         };
@@ -12930,6 +13212,12 @@ app.registerExtension({
               use_custom_audio: !!w("use_custom_audio")?.value,
               override_audio: !!w("override_audio")?.value,
               global_prompt: self.properties?.global_prompt || "",
+              // Whether anything is wired to ref_images, not how many images it carries:
+              // that is an upstream tensor's batch size and nothing here can know it
+              // before the graph runs. The endpoint turns this into a caveat on the
+              // preview rather than a count it would have to invent.
+              ref_images_connected:
+                self.inputs?.find(i => i.name === "ref_images")?.link != null,
             };
             const resp = await api.fetchApi("/minimax_director/compile_prompt", {
               method: "POST", body: JSON.stringify(body),

--- a/js/minimax_director.js
+++ b/js/minimax_director.js
@@ -6090,7 +6090,7 @@ class TimelineEditor {
           this.promptInput.value = isAnchorSeg ? "" : (seg.prompt || "");
           this.promptInput.placeholder = isAnchorSeg
             ? "Image Anchor — no prompt (inherits the previous segment)"
-            : "Enter prompt for selected segment...";
+            : "Enter prompt for selected segment...   (a line like  @ref1 says: hello  becomes dialogue)";
         }
         // Anchors are guide-only, so lock their prompt field but leave Guide Strength active.
         this.promptInput.disabled = isAnchorSeg;

--- a/js/minimax_director.js
+++ b/js/minimax_director.js
@@ -13495,8 +13495,17 @@ app.registerExtension({
             const d = await resp.json();
             if (d.status !== "success") throw new Error(d.message || "compile failed");
             pText.textContent = d.prompt || "";
+            // The word count is information, not a verdict: the guide suggests 350-500 for
+            // generation tasks, which is a lot for a 5-15s clip, so it sits in the badge
+            // where it can be glanced at rather than in the warnings where it would fire
+            // on almost every timeline.
             pBadge.textContent = `${d.mode} · ${d.format || ""} · ${d.shots} shot${d.shots === 1 ? "" : "s"} · `
-              + `${d.length}f / ${d.seconds}s · refs ${d.refs.images}i/${d.refs.videos}v/${d.refs.audios}a`;
+              + `${d.length}f / ${d.seconds}s · refs ${d.refs.images}i/${d.refs.videos}v/${d.refs.audios}a`
+              + (d.words ? ` · ${d.words} words` : "");
+            pBadge.title = d.words
+              ? `detailed_description is about ${d.words} words. The guide suggests 350-500 `
+                + `for generation tasks; editing descriptions scale with the source instead.`
+              : "";
             pWarn.textContent = (d.warnings || []).join("  •  ");
             pWarn.style.display = (!pCollapsed && pWarn.textContent) ? "block" : "none";
           } catch (e) {

--- a/js/minimax_director.js
+++ b/js/minimax_director.js
@@ -4932,145 +4932,200 @@ class TimelineEditor {
 
     for (let file of files) {
       if (!(file.type.startsWith("video/") || file.name.toLowerCase().match(/\.(mp4|webm|mkv|avi|mov|m4v|flv|wmv)$/))) continue;
+      const placed = await this._loadMotionFile(file, frameRate, targetFrameStart);
+      if (placed && targetFrameStart !== null) targetFrameStart = placed.nextStart;
+    }
+  }
 
-      await new Promise(async (resolve) => {
-        try {
-          // Load from local blob immediately — no waiting for server upload
-          const blobUrl = URL.createObjectURL(file);
+  // Positioning, segment creation and insertion — shared by the two ways a reference video
+  // can arrive: decoded by the browser, or described by the server when the browser will
+  // not touch it. One copy on purpose; the paths differ only in where the duration and the
+  // thumbnail came from.
+  _insertMotionSegment({ file, clipFrames, thumbB64, videoEl, blobUrl, videoFile,
+                         targetFrameStart }) {
+    const newLength = clipFrames;
+    let newStart = targetFrameStart;
 
-          const vid = document.createElement('video');
-          vid.crossOrigin = "Anonymous";
-          vid.preload = 'auto';
-          vid.muted = true;
-          vid.onerror = (e) => { console.error("Motion video load error", e); URL.revokeObjectURL(blobUrl); resolve(); };
+    if (newStart === null || newStart === undefined) {
+      newStart = 0;
+      this.timeline.motionSegments.sort((a, b) => a.start - b.start);
+      for (let i = 0; i < this.timeline.motionSegments.length; i++) {
+        const s = this.timeline.motionSegments[i];
+        if (newStart + newLength <= s.start) break;
+        newStart = Math.max(newStart, s.start + s.length);
+      }
+    } else {
+      const currentDuration = this.getVisualDurationFrames();
+      const tempId = "TEMP_" + Date.now();
+      this.timeline.motionSegments.push({ id: tempId, start: newStart, length: newLength, type: "temp" });
+      const result = this._applyCenterDragPhysics(this.timeline.motionSegments, tempId, newStart, newStart + newLength / 2, currentDuration, currentDuration, 1);
+      for (const shiftedSeg of result) {
+        const original = this.timeline.motionSegments.find(s => s.id === shiftedSeg.id);
+        if (original) original.start = shiftedSeg.resolvedStart !== undefined ? shiftedSeg.resolvedStart : shiftedSeg.start;
+      }
+      const tempSeg = this.timeline.motionSegments.find(s => s.id === tempId);
+      newStart = tempSeg.start;
+      this.timeline.motionSegments = this.timeline.motionSegments.filter(s => s.id !== tempId);
+    }
 
-          vid.onloadeddata = () => {
-            vid.onloadeddata = null; // prevent re-firing if src changes or browser buffers more data
-            const clipDurationSecs = vid.duration || 1;
-            const clipFrames = Math.max(1, Math.ceil(clipDurationSecs * frameRate));
-            let newLength = clipFrames;
-            let newStart = targetFrameStart;
+    const seg = {
+      id: Date.now().toString() + Math.random().toString(36).substr(2, 5),
+      type: "motion_video",
+      start: newStart,
+      length: newLength,
+      trimStart: 0,
+      videoDurationFrames: clipFrames,
+      videoFile: videoFile || "",   // filled in later when the upload runs in background
+      fileName: file.name,
+      videoStrength: 1.0,
+      videoAttentionStrength: 0.65,
+      resampleMode: "nearest",
+      previewThumbs: [],
+      previewThumbSourceFrames: clipFrames,
+      fileSize: file.size
+    };
+    if (videoEl) seg.videoEl = videoEl;
+    if (blobUrl) seg._blobUrl = blobUrl;
+    if (!videoFile) seg._uploading = true;
 
-            if (newStart === null) {
-              newStart = 0;
-              this.timeline.motionSegments.sort((a, b) => a.start - b.start);
-              for (let i = 0; i < this.timeline.motionSegments.length; i++) {
-                let s = this.timeline.motionSegments[i];
-                if (newStart + newLength <= s.start) break;
-                newStart = Math.max(newStart, s.start + s.length);
-              }
-            }
+    if (thumbB64) {
+      seg.imageB64 = thumbB64;
+      const imgObj = new Image();
+      imgObj.onload = () => { seg.imgObj = imgObj; this.render(); };
+      imgObj.src = thumbB64;
+    }
 
-            const currentDuration = this.getVisualDurationFrames();
-            if (targetFrameStart !== null) {
-              let tempId = "TEMP_" + Date.now();
-              this.timeline.motionSegments.push({ id: tempId, start: newStart, length: newLength, type: "temp" });
-              let result = this._applyCenterDragPhysics(this.timeline.motionSegments, tempId, newStart, newStart + newLength / 2, currentDuration, currentDuration, 1);
-              for (let shiftedSeg of result) {
-                let original = this.timeline.motionSegments.find(s => s.id === shiftedSeg.id);
-                if (original) original.start = shiftedSeg.resolvedStart !== undefined ? shiftedSeg.resolvedStart : shiftedSeg.start;
-              }
-              let tempSeg = this.timeline.motionSegments.find(s => s.id === tempId);
-              newStart = tempSeg.start;
-              this.timeline.motionSegments = this.timeline.motionSegments.filter(s => s.id !== tempId);
-              targetFrameStart = newStart + newLength;
-            }
+    this.timeline.motionSegments.push(seg);
+    this.timeline.motionSegments.sort((a, b) => a.start - b.start);
 
-            const seg = {
-              id: Date.now().toString() + Math.random().toString(36).substr(2, 5),
-              type: "motion_video",
-              start: newStart,
-              length: newLength,
-              trimStart: 0,
-              videoDurationFrames: clipFrames,
-              videoFile: "",  // filled in once background upload completes
-              fileName: file.name,
-              videoStrength: 1.0,
-              videoAttentionStrength: 0.65,
-              resampleMode: "nearest",
-              previewThumbs: [],
-              previewThumbSourceFrames: clipFrames,
-              videoEl: vid,
-              _uploading: true,
-              _blobUrl: blobUrl,
-              fileSize: file.size
-            };
+    if (!this.retakeMode) {
+      this.growTimelineIfNeeded(seg.start + seg.length);
+    }
 
-            vid.currentTime = 0.01;
-            vid.onseeked = () => {
-              vid.onseeked = null;
-              const canvas = document.createElement('canvas');
-              canvas.width = Math.min(vid.videoWidth, 512);
-              canvas.height = Math.round((vid.videoHeight / vid.videoWidth) * canvas.width);
-              const ctx = canvas.getContext('2d');
-              ctx.drawImage(vid, 0, 0, canvas.width, canvas.height);
-              seg.imageB64 = canvas.toDataURL('image/jpeg');
+    this.selectionType = "motion";
+    this.selectedIndex = this.timeline.motionSegments.findIndex(s => s.id === seg.id);
+    this.updateUIFromSelection();
+    this.commitChanges(true);
+    this.render();
+    return { seg, nextStart: newStart + newLength };
+  }
 
-              const imgObj = new Image();
-              imgObj.onload = () => { seg.imgObj = imgObj; this.render(); };
-              imgObj.src = seg.imageB64;
-
-              // Add to timeline immediately
-              this.timeline.motionSegments.push(seg);
-              this.timeline.motionSegments.sort((a, b) => a.start - b.start);
-
-              if (!this.retakeMode) {
-                this.growTimelineIfNeeded(seg.start + seg.length);
-              }
-
-              this.selectionType = "motion";
-              this.selectedIndex = this.timeline.motionSegments.findIndex(s => s.id === seg.id);
-              this.updateUIFromSelection();
-              this.commitChanges(true);
-              resolve(); // resolve immediately — don't block on upload
-              this._ensureThumbnails(seg);
-
-              // Background upload — runs while the user can already work.
-              // We intentionally do NOT change vid.src after upload — the blob URL
-              // works perfectly for local playback. Only videoFile needs updating
-              // so Python can find the file at generation time.
-              this._uploadVideoFile(file).then(filePath => {
-                for (let s of this.timeline.motionSegments) {
-                  if (s._blobUrl === blobUrl || s.id === seg.id) {
-                    s.videoFile = filePath;
-                    s._uploading = false;
-                  }
-                }
-                if (blobUrl && filePath) {
-                  this._thumbnailCache = this._thumbnailCache || new Map();
-                  this._thumbnailPromises = this._thumbnailPromises || new Map();
-                  if (this._thumbnailCache.has(blobUrl)) {
-                    this._thumbnailCache.set(filePath, this._thumbnailCache.get(blobUrl));
-                  }
-                  if (this._thumbnailPromises.has(blobUrl)) {
-                    this._thumbnailPromises.set(filePath, this._thumbnailPromises.get(blobUrl));
-                  }
-                }
-                const isOverrideAudio = !!(this.node.properties.overrideAudio || this.timeline.overrideAudio);
-                if (isOverrideAudio) {
-                  const s = this.timeline.motionSegments.find(s => s.id === seg.id);
-                  if (s) {
-                    this._preloadMotionAudioSegment(s);
-                  }
-                }
-                this.commitChanges(true);
-                this.render();
-              }).catch(err => {
-                console.error("[MiniMaxDirector] Background motion video upload failed", err);
-                const currentSeg = this.timeline.motionSegments.find(s => s.id === seg.id);
-                if (currentSeg) currentSeg._uploading = false;
-                this.render();
-              });
-            };
-          };
-
-          vid.src = blobUrl;
-
-        } catch (err) {
-          console.error("[MiniMaxDirector] Motion video processing failed", err);
-          resolve();
+  // Upload in the background so the clip is usable the moment it lands on the track.
+  _finishMotionUpload(seg, file, blobUrl) {
+    this._uploadVideoFile(file).then(filePath => {
+      for (const s of this.timeline.motionSegments) {
+        if (s._blobUrl === blobUrl || s.id === seg.id) {
+          s.videoFile = filePath;
+          s._uploading = false;
         }
+      }
+      if (blobUrl && filePath) {
+        this._thumbnailCache = this._thumbnailCache || new Map();
+        this._thumbnailPromises = this._thumbnailPromises || new Map();
+        if (this._thumbnailCache.has(blobUrl)) {
+          this._thumbnailCache.set(filePath, this._thumbnailCache.get(blobUrl));
+        }
+        if (this._thumbnailPromises.has(blobUrl)) {
+          this._thumbnailPromises.set(filePath, this._thumbnailPromises.get(blobUrl));
+        }
+      }
+      const isOverrideAudio = !!(this.node.properties.overrideAudio || this.timeline.overrideAudio);
+      if (isOverrideAudio) {
+        const s = this.timeline.motionSegments.find(s => s.id === seg.id);
+        if (s) this._preloadMotionAudioSegment(s);
+      }
+      this.commitChanges(true);
+      this.render();
+    }).catch(err => {
+      console.error("[MiniMaxDirector] Background motion video upload failed", err);
+      const currentSeg = this.timeline.motionSegments.find(s => s.id === seg.id);
+      if (currentSeg) currentSeg._uploading = false;
+      this.render();
+    });
+  }
+
+  // Try the browser first — a local blob shows the clip instantly, with no upload to wait
+  // on. If the browser will not decode it, fall back to the server rather than giving up.
+  _loadMotionFile(file, frameRate, targetFrameStart) {
+    return new Promise((resolve) => {
+      const blobUrl = URL.createObjectURL(file);
+      const vid = document.createElement('video');
+      vid.crossOrigin = "Anonymous";
+      vid.preload = 'auto';
+      vid.muted = true;
+
+      let settled = false;
+      const done = (value) => { if (!settled) { settled = true; resolve(value); } };
+
+      vid.onerror = () => {
+        // Chrome refuses plenty of codecs the renderer reads without complaint — HEVC,
+        // ProRes and 10-bit footage all live inside perfectly ordinary .mp4 and .mov
+        // files. This used to log to the console and stop, so picking such a file did
+        // nothing at all and never said why.
+        URL.revokeObjectURL(blobUrl);
+        this._placeMotionViaServer(file, frameRate, targetFrameStart).then(done);
+      };
+
+      vid.onloadeddata = () => {
+        vid.onloadeddata = null;   // browsers re-fire this as more data buffers
+        const clipFrames = Math.max(1, Math.ceil((vid.duration || 1) * frameRate));
+
+        vid.currentTime = 0.01;
+        vid.onseeked = () => {
+          vid.onseeked = null;
+          let thumb = "";
+          try {
+            const canvas = document.createElement('canvas');
+            canvas.width = Math.min(vid.videoWidth, 512);
+            canvas.height = Math.round((vid.videoHeight / vid.videoWidth) * canvas.width);
+            canvas.getContext('2d').drawImage(vid, 0, 0, canvas.width, canvas.height);
+            thumb = canvas.toDataURL('image/jpeg');
+          } catch (e) {
+            console.warn("[MiniMaxDirector] could not grab a thumbnail frame", e);
+          }
+
+          const { seg, nextStart } = this._insertMotionSegment({
+            file, clipFrames, thumbB64: thumb, videoEl: vid, blobUrl, targetFrameStart });
+          done({ nextStart });               // never block on the upload
+          this._ensureThumbnails(seg);
+          this._finishMotionUpload(seg, file, blobUrl);
+        };
+      };
+
+      vid.src = blobUrl;
+    });
+  }
+
+  // The file has to be uploaded before it can be probed, so this path is slower than the
+  // blob one — but it accepts everything the renderer accepts, which is the point.
+  async _placeMotionViaServer(file, frameRate, targetFrameStart) {
+    try {
+      const videoFile = await this._uploadVideoFile(file);
+      if (!videoFile) throw new Error("the upload did not complete");
+
+      const resp = await api.fetchApi("/minimax_director/probe_video", {
+        method: "POST", body: JSON.stringify({ file: videoFile }),
       });
+      const d = await resp.json();
+      if (d.status !== "success") throw new Error(d.message || "the server could not read it");
+      if (!d.duration) throw new Error("the file reports no duration");
+
+      const clipFrames = Math.max(1, Math.ceil(d.duration * frameRate));
+      const { seg, nextStart } = this._insertMotionSegment({
+        file, clipFrames, thumbB64: d.thumb || "", videoFile, targetFrameStart });
+      console.info(`[MiniMaxDirector] '${file.name}' (${d.codec || "unknown codec"}) could `
+        + `not be decoded by the browser; the server read it instead.`);
+      // deliberately no _ensureThumbnails here: the filmstrip is extracted through a
+      // <video> element too, so it would fail the same way. The frame the server sent is
+      // already on the segment.
+      return { nextStart };
+    } catch (err) {
+      console.error("[MiniMaxDirector] reference video could not be read", err);
+      alert(`Could not add "${file.name}".\n\n`
+        + `${err.message || err}\n\n`
+        + `The browser cannot decode this file and the server could not read it either. `
+        + `Re-encoding to H.264 in an MP4 container usually fixes it.`);
+      return null;
     }
   }
 

--- a/js/minimax_director.js
+++ b/js/minimax_director.js
@@ -1033,7 +1033,11 @@ function parseInitial(jsonStr) {
       }
       if (Array.isArray(p.segments)) {
         parsed.segments = p.segments.map(s => {
-          const { imgObj, videoEl, _isSeeking, thumbnails, _extractingThumbs, _sSecs, _lSecs, _tSecs, _dSecs, _uploading, _blobUrl, ...rest } = s;
+          // `isAnchor` is dropped rather than carried: the Image Anchor was an LTX
+          // concept this node never read, so an old timeline's flag is inert and would
+          // otherwise ride along in the JSON forever. Such a segment becomes an ordinary
+          // image with an empty prompt, which is what it already compiled to.
+          const { imgObj, videoEl, _isSeeking, thumbnails, _extractingThumbs, _sSecs, _lSecs, _tSecs, _dSecs, _uploading, _blobUrl, isAnchor, ...rest } = s;
           return rest;
         });
       }
@@ -3369,8 +3373,6 @@ class TimelineEditor {
         return;
       }
       if (this.selectionType === "image" && this.timeline.segments[this.selectedIndex]) {
-        // Anchors never own a prompt — ignore any input against them.
-        if (this.timeline.segments[this.selectedIndex].isAnchor) return;
         this.timeline.segments[this.selectedIndex].prompt = this.promptInput.value;
         this.commitChanges();
       } else if (this.selectionType === "motion") {
@@ -4490,8 +4492,7 @@ class TimelineEditor {
   }
 
   // --- Async Image Upload Logic (Handles multiple images simultaneously) ---
-  async handleImageUpload(files, targetFrameStart = null, explicitLength = null, opts = {}) {
-    const isAnchorUpload = !!opts.isAnchor;
+  async handleImageUpload(files, targetFrameStart = null, explicitLength = null) {
     const frameRate = this.getFrameRate();
     const durationFrames = this.getDurationFrames();
     const newLength = explicitLength !== null ? explicitLength : frameRate * 1; // Default to 1 second long
@@ -4573,11 +4574,6 @@ class TimelineEditor {
               length: constrainedLength,
               prompt: "",
               type: "image",
-              // Image Anchor: a guide-only keyframe. It is inserted into the latent
-              // exactly like a normal image guide (same guideStrength path), but it is
-              // EXCLUDED from the prompt-relay sync — it borrows the previous segment's
-              // prompt instead of owning one. See commitChanges() and the draw block.
-              isAnchor: isAnchorUpload,
               imageFile: imageFile,
               imageB64: imgUrl
             };
@@ -6267,16 +6263,13 @@ class TimelineEditor {
       this.vidAttnValue.style.display = "none";
 
       if (seg) {
-        const isAnchorSeg = !!seg.isAnchor;
         if (this.selectionType !== "motion") {
-          this.promptInput.value = isAnchorSeg ? "" : (seg.prompt || "");
-          this.promptInput.placeholder = isAnchorSeg
-            ? "Image Anchor — no prompt (inherits the previous segment)"
-            : "Enter prompt for selected segment...   (a line like  @ref1 says: hello  becomes dialogue)";
+          this.promptInput.value = seg.prompt || "";
+          this.promptInput.placeholder =
+            "Enter prompt for selected segment...   (a line like  @ref1 says: hello  becomes dialogue)";
         }
-        // Anchors are guide-only, so lock their prompt field but leave Guide Strength active.
-        this.promptInput.disabled = isAnchorSeg;
-        this.promptInput.style.opacity = isAnchorSeg ? "0.5" : "1.0";
+        this.promptInput.disabled = false;
+        this.promptInput.style.opacity = "1.0";
 
         const isImage = (this.selectionType === "image") && (seg.type === "image" || seg.type === "video");
         const strength = isImage ? (seg.guideStrength ?? 1.0) : 1.0;
@@ -7177,9 +7170,7 @@ class TimelineEditor {
         }
 
         if (isSelected) {
-          // Image Anchors get an orange outline so they read differently from
-          // prompt-synced segments (which stay white when selected).
-          const outlineColor = seg.isAnchor ? "#ff9d2e" : "#fff";
+          const outlineColor = "#fff";
           this.ctx.strokeStyle = outlineColor;
           this.ctx.lineWidth = 2;
           this.ctx.strokeRect(startX, RULER_HEIGHT + 1, pxWidth, this.blockHeight - 2);
@@ -7199,57 +7190,17 @@ class TimelineEditor {
           this.ctx.strokeRect(startX, RULER_HEIGHT + 1, pxWidth, this.blockHeight - 2);
         }
 
-        // Anchor glyph: drawn for anchors whether idle OR selected, so the marker
-        // stays visible on selection. Bottom-right corner, tiny dot fallback if thin.
-        if (seg.isAnchor && seg.type !== "ghost") {
-          const _anchBottom = RULER_HEIGHT + this.blockHeight;
-          if (pxWidth >= 24 && this.blockHeight > 30) {
-            const R = 9;
-            const cx = startX + pxWidth - 6 - R;
-            const cy = _anchBottom - 6 - R;
-            this.ctx.save();
-            const gs = R * 0.9;
-            this.ctx.strokeStyle = "#ffcf9b";
-            this.ctx.lineWidth = 1.2;
-            this.ctx.lineCap = "round";
-            this.ctx.beginPath();
-            this.ctx.arc(cx, cy - gs * 0.62, gs * 0.24, 0, Math.PI * 2);
-            this.ctx.stroke();
-            this.ctx.beginPath();
-            this.ctx.moveTo(cx, cy - gs * 0.4);
-            this.ctx.lineTo(cx, cy + gs * 0.72);
-            this.ctx.stroke();
-            this.ctx.beginPath();
-            this.ctx.moveTo(cx - gs * 0.5, cy - gs * 0.1);
-            this.ctx.lineTo(cx + gs * 0.5, cy - gs * 0.1);
-            this.ctx.stroke();
-            this.ctx.beginPath();
-            this.ctx.arc(cx, cy + gs * 0.05, gs * 0.62, Math.PI * 0.16, Math.PI * 0.84);
-            this.ctx.stroke();
-            this.ctx.restore();
-          } else if (pxWidth >= 6) {
-            this.ctx.save();
-            this.ctx.beginPath();
-            this.ctx.arc(startX + pxWidth / 2, _anchBottom - 7, 2.5, 0, Math.PI * 2);
-            this.ctx.fillStyle = "rgba(255, 157, 46, 0.95)";
-            this.ctx.fill();
-            this.ctx.restore();
-          }
-        }
         this.ctx.globalAlpha = 1.0;
       }
 
       // --- Prompt zones: boundary lines (always) + zone ribbon (toggle) ---
-      // A "zone" is the span one prompt governs. Image Anchors don't own a
-      // prompt (they inherit the preceding one), so they never open a new zone;
-      // the previous prompt's zone runs straight through them. This mirrors the
-      // prompt-relay logic used at export time, so what you see is what renders.
+      // A "zone" is the span one prompt governs.
       if (totalFrames > 0 && this.blockHeight > 20) {
         const zoneSegs = sortedSegments
           .filter(s => s.type !== "ghost")
           .slice()
           .sort((a, b) => a.start - b.start);
-        const realZoneSegs = zoneSegs.filter(s => !s.isAnchor);
+        const realZoneSegs = zoneSegs;
 
         if (realZoneSegs.length > 0) {
           const zones = realZoneSegs.map((s, i) => ({
@@ -10297,25 +10248,6 @@ class TimelineEditor {
         const effectiveStart = Math.max(seg.start, startFrames);
         const clippedEnd = Math.min(seg.start + seg.length, endFrames);
 
-        // Image Anchors are guide-only: they still get inserted as a keyframe by the
-        // Python guide node (which reads them from timeline_data by type "image"), but
-        // they must NOT create their own prompt-relay segment. Absorb their timespan
-        // (and any gap before them) into the preceding prompt so it "covers" the anchor.
-        // If an anchor is the very first thing on the timeline, its span is carried
-        // forward as pendingGap into the next real prompt segment.
-        if (seg.isAnchor) {
-          const absorb = clippedEnd - currentCursor;
-          if (absorb > 0) {
-            if (contiguousLengths.length > 0) {
-              contiguousLengths[contiguousLengths.length - 1] += absorb;
-            } else {
-              pendingGap += absorb;
-            }
-          }
-          currentCursor = Math.max(currentCursor, seg.start + seg.length);
-          continue;
-        }
-
         if (effectiveStart > currentCursor) {
           const gapLength = Math.min(effectiveStart, endFrames) - currentCursor;
           if (contiguousLengths.length > 0) {
@@ -11118,30 +11050,6 @@ class TimelineEditor {
     }
 
     // ==========================================
-    // 4b. Define Convert to / from Image Anchor (image segments only)
-    // ==========================================
-    let anchorToggleBtn = null;
-    if (trackType === "image" && seg.type === "image") {
-      anchorToggleBtn = document.createElement("button");
-      anchorToggleBtn.className = "mmxd-gap-menu-btn";
-      const anchorIcon = `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#ff9d2e" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="5" r="3"></circle><line x1="12" y1="22" x2="12" y2="8"></line><path d="M5 12H2a10 10 0 0 0 20 0h-3"></path></svg>`;
-      anchorToggleBtn.innerHTML = seg.isAnchor
-        ? `${anchorIcon} Convert to Image Segment`
-        : `${anchorIcon} Convert to Image Anchor`;
-      anchorToggleBtn.onclick = () => {
-        seg.isAnchor = !seg.isAnchor;
-        this.commitChanges();
-        // If this segment is the one shown in the side panel, refresh it so the
-        // prompt box enables/disables and the strength row updates immediately.
-        if (this.selectedSegmentIds && this.selectedSegmentIds.includes(seg.id)) {
-          this.updateUIFromSelection();
-        }
-        this.render();
-        this.dismissContextMenu();
-      };
-    }
-
-    // ==========================================
     // 5. Define Unlink Media & Mark Selection options
     // ==========================================
     const isVidLink = trackType === "video" && seg.id.endsWith("_v");
@@ -11246,12 +11154,6 @@ class TimelineEditor {
       this.deleteSelectedSegment();
       this.dismissContextMenu();
     };
-
-    // Very top: Convert to / from Image Anchor (image segments only)
-    if (anchorToggleBtn) {
-      menu.appendChild(anchorToggleBtn);
-      menu.appendChild(makeDivider());
-    }
 
     // Very top: Split at Playhead (if active/available)
     if (splitBtn) {
@@ -11372,23 +11274,6 @@ class TimelineEditor {
         fi.click();
       };
       menu.appendChild(imgBtn);
-
-      const anchorBtn = document.createElement("button");
-      anchorBtn.className = "mmxd-gap-menu-btn";
-      anchorBtn.innerHTML = `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#ff9d2e" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="5" r="3"></circle><line x1="12" y1="22" x2="12" y2="8"></line><path d="M5 12H2a10 10 0 0 0 20 0h-3"></path></svg> Image Anchor`;
-      anchorBtn.onclick = () => {
-        this.dismissContextMenu();
-        const fi = document.createElement("input");
-        fi.type = "file"; fi.accept = "image/*";
-        fi.addEventListener("change", (ev) => {
-          if (ev.target.files?.[0]) {
-            const gapLength = gap.frameEnd - gap.frameStart;
-            this.handleImageUpload([ev.target.files[0]], gap.frameStart, gapLength, { isAnchor: true });
-          }
-        });
-        fi.click();
-      };
-      menu.appendChild(anchorBtn);
 
       const pasteImageBtn = document.createElement("button");
       pasteImageBtn.className = "mmxd-gap-menu-btn";
@@ -11540,25 +11425,8 @@ class TimelineEditor {
         fi.click();
       });
 
-      const anchorBtn = document.createElement("button");
-      anchorBtn.className = "mmxd-gap-menu-btn";
-      anchorBtn.innerHTML = `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#ff9d2e" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="5" r="3"></circle><line x1="12" y1="22" x2="12" y2="8"></line><path d="M5 12H2a10 10 0 0 0 20 0h-3"></path></svg> Image Anchor`;
-      anchorBtn.addEventListener("click", () => {
-        this.dismissGapMenu();
-        const fi = document.createElement("input");
-        fi.type = "file"; fi.accept = "image/*";
-        fi.addEventListener("change", (ev) => {
-          if (ev.target.files?.[0]) {
-            const gapLength = gap.frameEnd - gap.frameStart;
-            this.handleImageUpload([ev.target.files[0]], gap.frameStart, gapLength, { isAnchor: true });
-          }
-        });
-        fi.click();
-      });
-
       menu.appendChild(textBtn);
       menu.appendChild(imgBtn);
-      menu.appendChild(anchorBtn);
       menu.appendChild(vidBtn);
       menu.appendChild(pasteImageBtn);
     } else if (currentTrack === "motion") {

--- a/js/minimax_director.js
+++ b/js/minimax_director.js
@@ -26,13 +26,19 @@ const MOTION_TRACK_HEIGHT = 80; // used as the Reference Video track height
 const CANVAS_HEIGHT = RULER_HEIGHT + BLOCK_HEIGHT + MOTION_TRACK_HEIGHT + AUDIO_TRACK_HEIGHT;
 const HANDLE_HIT_PX = 14;
 const MIN_SEGMENT_LENGTH = 6;
-// The overall_soundscape / non_diegetic_music strip is docked inside the global prompt
-// box, so the box has to be tall enough for both. MUST match .mmxd-sound-row's height in
-// the stylesheet — the CSS shortens the textarea by exactly this much, and if the two
-// disagree the prompt area either overlaps the strip or leaves a gap.
-const SOUND_ROW_HEIGHT = 54;
+// The overall_soundscape / non_diegetic_music / summary strip sits *beside* the global
+// prompt box as a flex sibling, not inside it. It used to be absolutely positioned on top
+// of the textarea, with the textarea shortened by a hard-coded calc() to make room — so
+// the two fought over the same space and the strip sat on the box's own border. As a flex
+// child the panel divides itself, and these constants only have to reserve node height.
+// The 12px of bottom padding clears the panel's absolutely-positioned drag strip.
+const SOUND_ROW_HEIGHT = 66;   // 50px of field + 4 top + 12 bottom to clear the resizer
 const GLOBAL_PROMPT_MIN_H = 60;                                    // the prompt box alone
 const GLOBAL_PROP_MIN_H = GLOBAL_PROMPT_MIN_H + SOUND_ROW_HEIGHT;  // prompt box + strip
+// The per-reference "describes / retained" strip in the segment properties panel, built
+// the same way. Hiding it with display:none gives the prompt box its height straight back.
+const REF_NOTE_ROW_HEIGHT = 66;
+const PROP_MIN_H = 90;                                             // prompt box alone
 const MAX_THUMBNAIL_DIM = 512; // Increased to maintain quality for taller images
 
 const HIDDEN_WIDGET_NAMES = ["timeline_data", "local_prompts", "segment_lengths", "guide_strength", "audio_data", "use_custom_audio", "inpaint_audio", "use_custom_motion", "override_audio"];
@@ -649,12 +655,14 @@ const STYLES = `
   /* --- Subject reference slots --- */
   .mmxd-characters-container { display: flex; flex-wrap: wrap; justify-content: flex-start; gap: 12px; margin-top: 6px; margin-bottom: 4px; box-sizing: border-box; width: 100%; flex-shrink: 0; }
   /* grows to nine slots, so they wrap into rows of three rather than shrinking to slivers */
-  .mmxd-character-slot { flex: 1 1 calc(33.333% - 8px); min-width: 120px; background: #1e1e1e; border: 1.5px dashed #444; border-radius: 8px; height: 148px; display: flex; flex-direction: column; align-items: center; justify-content: flex-start; padding: 4px; position: relative; cursor: pointer; overflow: hidden; transition: all 0.2s ease; box-sizing: border-box; }
+  /* height is set inline from the dragged panel size — deliberately not duplicated here */
+  .mmxd-character-slot { flex: 1 1 calc(33.333% - 8px); min-width: 120px; background: #1e1e1e; border: 1.5px dashed #444; border-radius: 8px; display: flex; flex-direction: column; align-items: center; justify-content: flex-start; padding: 4px; position: relative; cursor: pointer; overflow: hidden; transition: border-color 0.2s ease, background 0.2s ease; box-sizing: border-box; }
   .mmxd-character-slot:hover { border-color: #666; background: #252525; }
   .mmxd-character-slot.drag-over { border-color: #4fff8f; background: rgba(79, 255, 143, 0.05); }
   .mmxd-character-label { font-size: 10px; font-weight: bold; color: #888; margin-bottom: 2px; pointer-events: none; }
   .mmxd-character-placeholder { font-size: 9px; color: #666; text-align: center; pointer-events: none; margin-top: 10px; }
-  .mmxd-character-previews-row { display: flex; width: 100%; height: 52px; gap: 4px; position: relative; }
+  /* the only part of a slot that flexes, so dragging the panel taller grows the images */
+  .mmxd-character-previews-row { display: flex; width: 100%; flex: 1 1 auto; min-height: 44px; gap: 4px; position: relative; }
   .mmxd-character-preview-wrapper { flex: 1; height: 100%; position: relative; overflow: hidden; border-radius: 3px; background: #111; }
   .mmxd-character-preview { width: 100%; height: 100%; object-fit: cover; pointer-events: none; }
   .mmxd-character-delete { position: absolute; top: 2px; right: 2px; background: rgba(0, 0, 0, 0.85); color: #ff4444; border: none; border-radius: 50%; width: 14px; height: 14px; display: flex; align-items: center; justify-content: center; cursor: pointer; font-size: 9px; transition: background 0.15s; z-index: 10; padding: 0; }
@@ -662,8 +670,14 @@ const STYLES = `
   .mmxd-character-validate-btn { position: absolute; bottom: -8px; left: 50%; transform: translateX(-50%); background: rgba(0, 0, 0, 0.85); color: #e0e0e0; border: 1px solid #444; border-radius: 3px; padding: 2px 8px; font-size: 9px; font-weight: bold; cursor: pointer; transition: all 0.15s; z-index: 20; }
   .mmxd-character-validate-btn:hover { background: #4fff8f; color: #000; border-color: #4fff8f; }
   .mmxd-character-validate-btn.loading { background: #333; color: #888; cursor: wait; pointer-events: none; }
-  .mmxd-character-desc { width: 100%; height: 38px; background: #111; color: #e0e0e0; border: 1px solid #333; border-radius: 4px; font-size: 9px; resize: none; box-sizing: border-box; padding: 2px 4px; margin-top: 10px; outline: none; font-family: inherit; z-index: 10; }
-  .mmxd-character-desc:focus { border-color: #4fff8f; }
+  /* Two captioned boxes per slot: what the subject IS, and what has to survive into the
+     target video. Both are fixed height so the previews row above them takes the slack. */
+  .mmxd-character-field { position: relative; width: 100%; flex: 0 0 32px; margin-top: 6px; background: #111; border: 1px solid #333; border-radius: 4px; box-sizing: border-box; z-index: 10; }
+  .mmxd-character-field.mmxd-field-first { margin-top: 10px; }
+  .mmxd-character-field.focus-active { border-color: #4fff8f; }
+  .mmxd-character-field-label { position: absolute; top: 2px; left: 5px; font-size: 8px; font-weight: bold; color: #5a5a5a; text-transform: uppercase; letter-spacing: 0.5px; pointer-events: none; user-select: none; z-index: 5; }
+  .mmxd-character-desc { position: absolute; top: 12px; left: 0; width: 100%; height: calc(100% - 12px); background: transparent; color: #e0e0e0; border: none; font-size: 9px; line-height: 1.3; resize: none; box-sizing: border-box; padding: 0 4px 2px 4px; outline: none; font-family: inherit; }
+  .mmxd-character-desc::placeholder { color: #4a4a4a; }
   /* --- per-reference kind / retention controls --- */
   .mmxd-ref-controls { display: flex; gap: 4px; width: 100%; margin-top: 4px; box-sizing: border-box; }
   .mmxd-ref-controls .mmxd-msel { flex: 1 1 0; min-width: 0; height: 20px; font-size: 9px; padding: 0 4px 0 6px; }
@@ -693,8 +707,13 @@ const STYLES = `
   /* The wrapper positions its children absolutely, so this row sits at the bottom and
      the prompt area above it is shortened by exactly the same amount. Nothing here
      changes the node's height: the container keeps whatever the user resized it to. */
-  .mmxd-sound-row { position: absolute; bottom: 0; left: 0; width: 100%; height: 54px; display: flex; gap: 6px; padding: 0 8px 6px 8px; box-sizing: border-box; }
-  .mmxd-prompt-area.mmxd-has-sound { height: calc(100% - 20px - 54px); }
+  /* A flex child of the properties panel, not an overlay inside the prompt box. It was
+     absolutely positioned on top of the textarea, which meant the two fought over the
+     same space: the box shrank by a hard-coded calc() and the strip sat on its border. */
+  .mmxd-sound-row { flex: 0 0 66px; width: 100%; display: flex; gap: 6px; padding: 4px 0 12px 0; box-sizing: border-box; }
+  /* same two-field shape as the sound strip, but a flex child of the properties panel
+     rather than a strip docked inside the prompt box — see REF_NOTE_ROW_HEIGHT */
+  .mmxd-ref-note-row { flex: 0 0 66px; width: 100%; display: flex; gap: 6px; padding: 4px 0 12px 0; box-sizing: border-box; }
   .mmxd-sound-field { position: relative; flex: 1 1 0; min-width: 0; background: #1c1c1c; border: 1px solid #111; border-radius: 4px; box-sizing: border-box; }
   .mmxd-sound-field.focus-active { border-color: #888; }
   .mmxd-sound-label { position: absolute; top: 3px; left: 6px; font-size: 8px; font-weight: bold; color: #5a5a5a; text-transform: uppercase; letter-spacing: 0.5px; pointer-events: none; user-select: none; z-index: 5; }
@@ -860,10 +879,19 @@ const REF_ROLE_TIP =
   "defines a subject — it only defines a look, so it gets no <Picture> entry";
 
 // Slots wrap three to a row; the node has to reserve the rows or it crops the last one.
-const SUBJECT_SLOT_H = 148, SUBJECT_SLOT_GAP = 12;
-function subjectPanelHeight(slotCount) {
+// The slot height is the user's, dragged from the strip under the panel — the previews
+// row is the only part that flexes, so every pixel gained goes to the images rather than
+// to the text boxes. Unlike SOUND_ROW_HEIGHT there is no matching CSS literal to keep in
+// step: the height is set inline per slot, precisely so there is only one of it.
+// 8 padding + 44 previews + 42 first field + 38 second field + 24 controls
+const SUBJECT_SLOT_MIN_H = 160;
+const SUBJECT_SLOT_DEFAULT_H = 215;
+const SUBJECT_SLOT_GAP = 12;
+const SUBJECT_RESIZER_H = 12;
+function subjectPanelHeight(slotCount, slotHeight) {
   const rows = Math.max(1, Math.ceil(slotCount / 3));
-  return rows * SUBJECT_SLOT_H + (rows - 1) * SUBJECT_SLOT_GAP + 20;
+  const h = Math.max(SUBJECT_SLOT_MIN_H, slotHeight || SUBJECT_SLOT_DEFAULT_H);
+  return rows * h + (rows - 1) * SUBJECT_SLOT_GAP + 20 + SUBJECT_RESIZER_H;
 }
 
 function emptySubjectSlot() {
@@ -2567,6 +2595,9 @@ class TimelineEditor {
     refOptionSelect.addEventListener("change", (e) => {
       this.timeline.reference_mode = e.target.value;
       this.commitChanges();
+      // the describes/retained strip only exists in ref2va, so it has to appear and
+      // disappear with the switch rather than waiting for the next selection change
+      this.updateUIFromSelection();
     });
     this.refOptionSelect = refOptionSelect;
 
@@ -3070,7 +3101,8 @@ class TimelineEditor {
     const globalPromptWrapper = document.createElement("div");
     globalPromptWrapper.className = "mmxd-prompt-wrapper";
     globalPromptWrapper.style.width = "100%";
-    globalPromptWrapper.style.height = "100%";
+    globalPromptWrapper.style.flex = "1 1 auto";
+    globalPromptWrapper.style.minHeight = "0";
 
     this.globalPromptLabel = document.createElement("div");
     this.globalPromptLabel.className = "mmxd-prompt-label";
@@ -3078,7 +3110,7 @@ class TimelineEditor {
     globalPromptWrapper.appendChild(this.globalPromptLabel);
 
     this.globalPromptInput = document.createElement("textarea");
-    this.globalPromptInput.className = "mmxd-prompt-area mmxd-has-sound";
+    this.globalPromptInput.className = "mmxd-prompt-area";
     this.globalPromptInput.placeholder =
       "Enter global prompt here...  (Audio: / Music: lines are lifted into the two boxes below)";
     this.globalPromptInput.spellcheck = true;
@@ -3165,7 +3197,6 @@ class TimelineEditor {
     this.summaryInput = makeSoundField(
       "summary", "summary",
       "One paragraph on the target video and what each reference is for. The [task type] prefix is added for you.");
-    globalPromptWrapper.appendChild(soundRow);
 
     this.globalPromptInput.addEventListener("input", (e) => {
       const val = e.target.value;
@@ -3237,6 +3268,7 @@ class TimelineEditor {
     });
 
     globalPropContainer.appendChild(globalPromptWrapper);
+    globalPropContainer.appendChild(soundRow);
     globalPropContainer.appendChild(globalPropResizer);
 
     const propResizer = document.createElement("div");
@@ -3262,7 +3294,7 @@ class TimelineEditor {
           stopDrag();
           return;
         }
-        const newH = Math.max(90, startH + (ev.clientY - startY));
+        const newH = Math.max(this._propMinH(), startH + (ev.clientY - startY));
         this.propHeight = newH;
         this.node.properties.propHeight = newH;
         propContainer.style.height = `${newH}px`;
@@ -3291,7 +3323,10 @@ class TimelineEditor {
     this.promptWrapper = document.createElement("div");
     this.promptWrapper.className = "mmxd-prompt-wrapper";
     this.promptWrapper.style.width = "100%";
-    this.promptWrapper.style.height = "100%";
+    // flex rather than height:100% so the reference-note strip below can take its own
+    // room when it is shown, and give it straight back when it is hidden
+    this.promptWrapper.style.flex = "1 1 auto";
+    this.promptWrapper.style.minHeight = "0";
     this.promptWrapper.style.display = "none";
 
     this.segmentPromptLabel = document.createElement("div");
@@ -3348,9 +3383,67 @@ class TimelineEditor {
     this.audioInfoArea = document.createElement("div");
     this.audioInfoArea.className = "mmxd-audio-info";
 
+    // --- Reference note strip -------------------------------------------------------
+    // Sits in propContainer beside the prompt box rather than inside it, because the
+    // audio branch of updateUIFromSelection hides promptWrapper outright — and an audio
+    // clip is exactly one of the references that needs a retention note.
+    this.refNoteRow = document.createElement("div");
+    this.refNoteRow.className = "mmxd-ref-note-row";
+    this.refNoteRow.style.display = "none";
+
+    const makeRefNoteField = (label, placeholder) => {
+      const field = document.createElement("div");
+      field.className = "mmxd-sound-field";
+
+      const cap = document.createElement("div");
+      cap.className = "mmxd-sound-label";
+      cap.textContent = label;
+      field.appendChild(cap);
+
+      const area = document.createElement("textarea");
+      area.className = "mmxd-sound-area";
+      area.placeholder = placeholder;
+      area.spellcheck = true;
+      area.addEventListener("focus", () => {
+        field.classList.add("focus-active");
+        this.wrapper.classList.add("has-focus");
+      });
+      area.addEventListener("blur", () => {
+        field.classList.remove("focus-active");
+        this.wrapper.classList.remove("has-focus");
+      });
+      field.appendChild(area);
+      this.refNoteRow.appendChild(field);
+      return { field, area };
+    };
+
+    const descField = makeRefNoteField(
+      "describes", "what this image defines, e.g. a long red wool coat");
+    const noteField = makeRefNoteField(
+      "retained", "what survives into the video — leave empty for the default");
+    this.refDescField = descField.field;
+    this.refDescInput = descField.area;
+    this.refNoteInput = noteField.area;
+
+    // Write to the timeline array, never to the segment object the selection handed us:
+    // while a drag is in flight that is a preview clone and the edit would be discarded.
+    const writeRefText = (key, value) => {
+      const list = this.getSegmentArray(this.selectionType);
+      const target = list && list[this.selectedIndex];
+      if (!target) return;
+      target[key] = value;
+      this.commitChanges(true);
+      if (this.node?._mmxRefreshPrompt) this.node._mmxRefreshPrompt();
+    };
+    this.refDescInput.addEventListener("input",
+      () => writeRefText("refDesc", this.refDescInput.value));
+    this.refNoteInput.addEventListener("input",
+      () => writeRefText("refNote", this.refNoteInput.value));
+
     propContainer.appendChild(this.promptWrapper);
     propContainer.appendChild(this.motionInfoArea);
     propContainer.appendChild(this.audioInfoArea);
+    propContainer.appendChild(this.refNoteRow);
     propContainer.appendChild(propResizer);
 
     this.wrapper.addEventListener("dragover", (e) => {
@@ -5733,6 +5826,56 @@ class TimelineEditor {
     }
   }
 
+  // The properties panel has to hold the prompt box *and*, when a reference is selected,
+  // the note strip. Without this the default 90px panel would leave the prompt box 24px.
+  _propMinH() {
+    const showing = this.refNoteRow && this.refNoteRow.style.display !== "none";
+    return PROP_MIN_H + (showing ? REF_NOTE_ROW_HEIGHT : 0);
+  }
+
+  // Opens the panel far enough that showing the strip does not squeeze the prompt box to
+  // nothing. Only ever grows — a panel the user has already dragged taller is left alone.
+  _growPropForRefNote() {
+    const min = this._propMinH();
+    if (!this.propContainer || this.propHeight >= min) return;
+    this.propHeight = min;
+    if (this.node?.properties) this.node.properties.propHeight = min;
+    this.propContainer.style.height = `${min}px`;
+    if (this.node?.setDirtyCanvas && typeof this.node.computeSize === "function"
+        && this.node.size) {
+      this.node.setSize([this.node.size[0], this.node.computeSize()[1]]);
+      this.node.setDirtyCanvas(true, true);
+    }
+  }
+
+  // Shows the describes/retained strip for whichever reference is selected, and fills it.
+  // Hidden entirely with refs off: with no <Subject>/<Picture>/<Video>/<Audio> labels in
+  // the prompt there is nothing for either sentence to attach to.
+  _syncRefNoteRow(seg) {
+    if (!this.refNoteRow) return;
+    const refsOn = String(this.timeline.reference_mode || "OFF").toUpperCase() !== "OFF";
+    const isRef = !!seg && (
+      this.selectionType === "motion" || this.selectionType === "audio" ||
+      (this.selectionType === "image" && (seg.type === "image" || seg.type === "video")));
+
+    if (!refsOn || !isRef || this.retakeMode) {
+      this.refNoteRow.style.display = "none";
+      return;
+    }
+    this.refNoteRow.style.display = "flex";
+    this._growPropForRefNote();
+
+    // `describes` only means something for an image that defines a subject rather than
+    // anchoring a frame — every other reference has just the one sentence.
+    const describes = this.selectionType === "image" && seg.refRole === "subject";
+    this.refDescField.style.display = describes ? "" : "none";
+    if (describes) this.refDescInput.value = seg.refDesc || "";
+    this.refNoteInput.value = seg.refNote || "";
+    this.refNoteInput.placeholder = this.selectionType === "audio"
+      ? "what the target keeps from this audio — leave empty for the default"
+      : "what survives into the video — leave empty for the default";
+  }
+
   updateUIFromSelection() {
     if (this.selectedSegmentIds && this.isMultiSelectActive()) {
       if (this.globalPromptInput) {
@@ -5781,6 +5924,9 @@ class TimelineEditor {
       if (this.segmentBoundsDisplay) {
         this.segmentBoundsDisplay.textContent = "Multiple Segments Selected";
       }
+      // there is no single reference to annotate, and leaving the strip up would show
+      // the previously selected segment's text as if it belonged to this selection
+      this._syncRefNoteRow(null);
       return;
     }
 
@@ -5827,6 +5973,10 @@ class TimelineEditor {
       this.promptInput.placeholder = "";
       this.promptInput.style.opacity = "";
     }
+
+    // Set once here rather than in each branch below: the strip belongs to the selected
+    // segment, not to whichever of the prompt box / motion info / audio info is on show.
+    this._syncRefNoteRow(seg);
 
     if (this.retakeMode) {
       if (this.promptWrapper) this.promptWrapper.style.display = "block";
@@ -9286,6 +9436,14 @@ class TimelineEditor {
     return this.timeline.subjects;
   }
 
+  // Dragged from the strip under the panel and remembered per node, exactly like
+  // propHeight and globalPropHeight. Clamped on read so a workflow saved when the slot
+  // was a fixed 148px does not come back too short for the two text boxes.
+  subjectSlotHeight() {
+    const stored = this.node?.properties?.subjectSlotHeight;
+    return Math.max(SUBJECT_SLOT_MIN_H, stored || SUBJECT_SLOT_DEFAULT_H);
+  }
+
   // Three always visible, then one empty slot ahead of whatever is filled, so the panel
   // grows only as far as it is used instead of showing nine empty boxes on day one.
   visibleSlotCount() {
@@ -9318,8 +9476,12 @@ class TimelineEditor {
       }
     });
     slot.addEventListener("click", (e) => {
+      // clicking anywhere else in the slot opens a file picker, so every interactive
+      // child has to be named here — including the field wrappers, whose border and
+      // caption are part of the box the user is aiming at
       if (e.target.closest(".mmxd-character-delete") ||
           e.target.closest(".mmxd-character-validate-btn") ||
+          e.target.closest(".mmxd-character-field") ||
           e.target.closest(".mmxd-character-desc") ||
           e.target.closest(".mmxd-msel")) return;
 
@@ -9338,16 +9500,81 @@ class TimelineEditor {
   }
 
   createCharacterSlots(parent) {
+    const wrap = document.createElement("div");
+    wrap.style.position = "relative";
+    wrap.style.width = "100%";
+    wrap.style.flexShrink = "0";
+
     const container = document.createElement("div");
     container.className = "mmxd-characters-container";
 
     this.subjectSlots();
     this.characterSlots = [];
 
-    parent.appendChild(container);
+    wrap.appendChild(container);
+    wrap.appendChild(this._buildSubjectResizer());
+    parent.appendChild(wrap);
     this.charPanelContainer = container;
-    this.charPanelHeight = subjectPanelHeight(3);
+    this.charPanelHeight = subjectPanelHeight(3, this.subjectSlotHeight());
     this.updateCharacterSlotsUI();
+  }
+
+  // Same grab strip as the prompt and global-prompt panels, so the reference panel resizes
+  // the way every other part of the editor already does. Only the slot height is stored;
+  // the panel height follows from it and the row count.
+  _buildSubjectResizer() {
+    const bar = document.createElement("div");
+    bar.style.position = "absolute";
+    bar.style.bottom = "0px";
+    bar.style.left = "0px";
+    bar.style.width = "100%";
+    bar.style.height = `${SUBJECT_RESIZER_H}px`;
+    bar.style.cursor = "ns-resize";
+    bar.style.display = "flex";
+    bar.style.justifyContent = "center";
+    bar.style.alignItems = "flex-end";
+    bar.style.paddingBottom = "4px";
+    bar.title = "Drag to resize the reference images";
+    bar.innerHTML = `<div style="width: 40px; height: 4px; background: rgba(255,255,255,0.1); border-radius: 2px;"></div>`;
+
+    bar.addEventListener("mousedown", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const startY = e.clientY;
+      const startH = this.subjectSlotHeight();
+
+      const doDrag = (ev) => {
+        if (ev.buttons === 0) { stopDrag(); return; }
+        // one row of slots follows the pointer 1:1; with two rows the panel grows twice
+        // as fast as the drag, which is the same deal the other resizers make
+        const newH = Math.max(SUBJECT_SLOT_MIN_H, startH + (ev.clientY - startY));
+        if (this.node?.properties) this.node.properties.subjectSlotHeight = newH;
+        this._applySubjectSlotHeight();
+      };
+      const stopDrag = () => {
+        window.removeEventListener("mousemove", doDrag, true);
+        window.removeEventListener("mouseup", stopDrag, true);
+        document.body.style.cursor = "default";
+        this.commitChanges(true);
+      };
+
+      document.body.style.cursor = "ns-resize";
+      window.addEventListener("mousemove", doDrag, true);
+      window.addEventListener("mouseup", stopDrag, true);
+    });
+    return bar;
+  }
+
+  // Pushes the dragged height onto every slot element and re-reserves the node's room.
+  _applySubjectSlotHeight() {
+    const h = this.subjectSlotHeight();
+    (this.characterSlots || []).forEach((el) => { el.style.height = `${h}px`; });
+    this.charPanelHeight = subjectPanelHeight(this.characterSlots?.length || 3, h);
+    if (this.node?.setDirtyCanvas && typeof this.node.computeSize === "function"
+        && this.node.size) {
+      this.node.setSize([this.node.size[0], this.node.computeSize()[1]]);
+      this.node.setDirtyCanvas(true, true);
+    }
   }
 
   // Adds or removes slot elements so the DOM matches visibleSlotCount(). Called from
@@ -9358,6 +9585,7 @@ class TimelineEditor {
     const want = this.visibleSlotCount();
     const slots = this.subjectSlots();
     while (slots.length < want) slots.push(emptySubjectSlot());
+    const slotH = this.subjectSlotHeight();
     while (this.characterSlots.length < want) {
       const el = this._buildSubjectSlotEl(this.characterSlots.length);
       container.appendChild(el);
@@ -9366,10 +9594,11 @@ class TimelineEditor {
     while (this.characterSlots.length > want) {
       this.characterSlots.pop().remove();
     }
+    this.characterSlots.forEach((el) => { el.style.height = `${slotH}px`; });
 
     // Slots wrap three to a row, so the panel's reserved height has to follow the row
     // count or the node crops the last row the moment a fourth subject is added.
-    const height = subjectPanelHeight(want);
+    const height = subjectPanelHeight(want, slotH);
     const grew = height !== this.charPanelHeight;
     this.charPanelHeight = height;
     // Only once the panel has been through a full build: during construction the widget's
@@ -9527,16 +9756,42 @@ class TimelineEditor {
 
         slot.appendChild(previewsRow);
 
-        const descInput = document.createElement("textarea");
-        descInput.className = "mmxd-character-desc";
-        descInput.value = data.description || "";
-        descInput.placeholder = "manual description...";
-        descInput.addEventListener("input", () => {
-          subjects[i].description = descInput.value;
-          this.commitChanges();
-        });
-        descInput.addEventListener("click", (e) => { e.stopPropagation(); });
-        slot.appendChild(descInput);
+        // Two captioned boxes: what the subject IS (the <Subject N> definition) and what
+        // has to survive into the target video (the retention_analysis line). They are
+        // different sentences in different sections of the prompt, so writing one has
+        // never been a way to say the other.
+        const makeSlotField = (label, key, placeholder, first) => {
+          const field = document.createElement("div");
+          field.className = "mmxd-character-field" + (first ? " mmxd-field-first" : "");
+
+          const cap = document.createElement("div");
+          cap.className = "mmxd-character-field-label";
+          cap.textContent = label;
+          field.appendChild(cap);
+
+          const area = document.createElement("textarea");
+          area.className = "mmxd-character-desc";
+          area.value = data[key] || "";
+          area.placeholder = placeholder;
+          area.spellcheck = true;
+          area.addEventListener("input", () => {
+            subjects[i][key] = area.value;
+            this.commitChanges();
+            if (this.node?._mmxRefreshPrompt) this.node._mmxRefreshPrompt();
+          });
+          area.addEventListener("focus", () => field.classList.add("focus-active"));
+          area.addEventListener("blur", () => field.classList.remove("focus-active"));
+          // the slot's own click handler opens a file picker unless the click lands on a
+          // child it knows about
+          area.addEventListener("click", (e) => { e.stopPropagation(); });
+          field.appendChild(area);
+          slot.appendChild(field);
+          return area;
+        };
+
+        makeSlotField("describes", "description", "a woman in a red coat…", true);
+        makeSlotField("retained", "retentionNote",
+                      "identity, face and clothing — leave empty for the default");
 
         // What this subject IS, and how closely to follow it. The kind only supplies a
         // noun for the definition line when no description is typed, so a description
@@ -9617,6 +9872,9 @@ class TimelineEditor {
           clip_name: clip_name,
           image_b64: b64_images,
           char_index: idx,
+          // so the model is asked about a place or a garment when that is what the slot
+          // holds, instead of being asked for hair and clothing regardless
+          kind: this.subjectSlots()[idx]?.kind || "person",
           provider: this.timeline.analyzeProvider || "ollama",
           base_url: this.timeline.analyzeBaseUrl || "",
           model: this.timeline.analyzeModel || "",
@@ -9625,6 +9883,11 @@ class TimelineEditor {
       const result = await resp.json();
       if (result.status === "success") {
         this.subjectSlots()[idx].description = result.description;
+        // A model that ignored the two-line format returns everything as the description
+        // and nothing here, which must not wipe a note the user wrote by hand.
+        if (result.retention_note) {
+          this.subjectSlots()[idx].retentionNote = result.retention_note;
+        }
         btn.textContent = "Success!";
         setTimeout(() => { this.updateCharacterSlotsUI(); this.commitChanges(); }, 1500);
       } else {
@@ -13092,7 +13355,9 @@ app.registerExtension({
           const globalPropH = self._timelineEditor ? (self._timelineEditor.globalPropHeight || 60) : 60;
           // Reserve room for the @refN reference panel at the bottom so the node doesn't
           // collapse and crop it whenever ComfyUI recomputes the node height.
-          const charPanelH = self._timelineEditor ? (self._timelineEditor.charPanelHeight || subjectPanelHeight(3)) : subjectPanelHeight(3);
+          const charPanelH = self._timelineEditor
+            ? (self._timelineEditor.charPanelHeight || subjectPanelHeight(3, self.properties?.subjectSlotHeight))
+            : subjectPanelHeight(3, self.properties?.subjectSlotHeight);
           const nodeWidth = self.size?.[0] || width || 1375;
           return [Math.max(10, nodeWidth - 30), canvasH + propH + globalPropH + charPanelH + 160];
         };

--- a/minimax_chain.py
+++ b/minimax_chain.py
@@ -254,14 +254,9 @@ class MiniMaxH3DirectorChain(io.ComfyNode):
                 plan.fmt_seconds((offset + span) / fps), p["prompt"]))
 
             if p["ref_mode_on"]:
-                ref_imgs = []
-                for slot in p["ref_image_slots"]:
-                    if slot["source"] == "char":
-                        img = slot["image"]
-                        ref_imgs.append(media.load_image_source(img.get("b64", ""),
-                                                                img.get("name", "")))
-                    elif slot["source"] == "timeline":
-                        ref_imgs.append(slot["event"]["tensor"][:1])
+                # the Director's loader, not a second copy of it — this node has no
+                # ref_images socket of its own, so those slots are never planned here
+                ref_imgs = director.load_ref_image_tensors(p["ref_image_slots"], fit)
                 if first_frame is not None and len(ref_imgs) < plan.MAX_REF_IMAGES:
                     ref_imgs.append(first_frame)
                 out = mm.MiniMaxH3ReferenceToVideo.execute(

--- a/minimax_director.py
+++ b/minimax_director.py
@@ -161,6 +161,44 @@ def _load_event_tensor(ev, fps, win_start):
     return media.load_image_tensor(seg)
 
 
+def load_ref_image_tensors(slots, fit, ref_images=None):
+    """Turn the planner's <Picture i> slots into tensors, in the order it numbered them.
+
+    The slot vocabulary is minimax_plan's, so this is the one place that has to know what
+    "char" / "input" / "timeline" mean and which frame of a video segment a keyframe role
+    picks out. The chain node grew its own copy of this loop and the two drifted: that one
+    ignored the ref_images socket entirely and never fitted a keyframe to the canvas, so a
+    chained render silently dropped references the Director would have sent.
+
+    `fit` scales a tensor to the resolved canvas. Only real keyframes go through it — a
+    plain reference is not composited into the video, so cropping it to the output aspect
+    would throw away reference the model could have used.
+    """
+    tensors = []
+    input_cursor = 0
+    for slot in slots:
+        source = slot["source"]
+        if source == "char":
+            img = slot["image"]
+            tensors.append(media.load_image_source(img.get("b64", ""), img.get("name", "")))
+        elif source == "input":
+            # planned from a count the caller supplied, so an unconnected socket here means
+            # the plan and the caller disagree — skip rather than index into nothing
+            if ref_images is None:
+                continue
+            tensors.append(ref_images[input_cursor:input_cursor + 1])
+            input_cursor += 1
+        else:
+            tensor = slot["event"]["tensor"]
+            if slot.get("keyframe") == plan.ROLE_LAST:
+                tensors.append(fit(tensor[-1:]))
+            elif slot.get("keyframe"):
+                tensors.append(fit(tensor[:1]))
+            else:
+                tensors.append(tensor[:1])
+    return tensors
+
+
 class _Unconnected:
     """Distinguishes an empty optional socket from a lazy one that is merely unevaluated.
 
@@ -452,25 +490,7 @@ class MiniMaxH3Director(io.ComfyNode):
         # --- reference payloads ------------------------------------------------------
         ref_image_tensors, ref_videos, ref_video_audios, ref_audios = [], {}, {}, {}
         if p["ref_mode_on"]:
-            input_cursor = 0
-            for slot in p["ref_image_slots"]:
-                src = slot["source"]
-                if src == "char":
-                    img = slot["image"]
-                    ref_image_tensors.append(
-                        media.load_image_source(img.get("b64", ""), img.get("name", "")))
-                elif src == "input":
-                    ref_image_tensors.append(ref_images[input_cursor:input_cursor + 1])
-                    input_cursor += 1
-                else:
-                    ev = slot["event"]
-                    tensor = ev["tensor"]
-                    if slot.get("keyframe") == plan.ROLE_LAST:
-                        ref_image_tensors.append(fit(tensor[-1:]))
-                    elif slot.get("keyframe"):
-                        ref_image_tensors.append(fit(tensor[:1]))
-                    else:
-                        ref_image_tensors.append(tensor[:1])
+            ref_image_tensors = load_ref_image_tensors(p["ref_image_slots"], fit, ref_images)
 
             for seg in p["ref_video_segs"]:
                 idx = len(ref_videos)

--- a/minimax_director.py
+++ b/minimax_director.py
@@ -498,9 +498,22 @@ class MiniMaxH3Director(io.ComfyNode):
                 seg_len = float(seg.get("length", 1))
                 offset = max(0.0, win_start - seg_start)
                 trim = float(seg.get("trimStart", 0)) + offset
-                clip_sec = min(plan.REF_VIDEO_MAX_SEC,
-                               max(plan.REF_VIDEO_MIN_SEC, (seg_len - offset) / fps))
-                frames = media.load_video_tensor(seg["videoFile"], trim / fps, clip_sec)
+                # The segment's own length is the answer, capped only at the model card's
+                # ceiling. It used to be floored at 2s as well, which meant trimming a clip
+                # shorter than that silently handed the VAE *more* than was asked for —
+                # the opposite of what someone trimming it down is trying to do. The
+                # planner already warns when a clip is under the card's 2s minimum.
+                clip_sec = min(plan.REF_VIDEO_MAX_SEC, (seg_len - offset) / fps)
+                # Reference frames are VAE-encoded whole and then ride through every
+                # sampling step, so their resolution is the largest single lever on memory:
+                # halving the short edge is roughly a quarter of the footprint. Per clip,
+                # because one reference may be carrying a look worth the pixels while
+                # another is only carrying a camera move.
+                short_edge = int(seg.get("refSize") or plan.REF_VIDEO_SHORT_EDGE)
+                frames = media.load_video_tensor(
+                    seg["videoFile"], trim / fps, clip_sec,
+                    max_short_edge=short_edge,
+                    max_pixels=int(short_edge * short_edge * plan.REF_VIDEO_ASPECT_BUDGET))
                 if frames.shape[0] < 5:
                     log.warning("[MiniMaxDirector] Reference video '%s' is shorter than 5 "
                                 "frames — skipped.", seg.get("fileName", seg["videoFile"]))

--- a/minimax_media.py
+++ b/minimax_media.py
@@ -236,6 +236,14 @@ async def compile_prompt_endpoint(request):
                                 "first and last frame. Switch to 'Refs ON (ref2va)'." % middles)
         if p["ref_mode_on"] and len(p["ref_image_slots"]) >= plan.MAX_REF_IMAGES:
             warnings.append("Reference images are capped at %d." % plan.MAX_REF_IMAGES)
+        # The batch on the ref_images socket only exists once the graph runs, so the
+        # preview cannot number around it. Say so: the alternative is a prompt that shows
+        # <Picture 2> where the render will send <Picture 5>, with nothing to explain why.
+        if (p["ref_mode_on"] and bool(data.get("ref_images_connected"))
+                and not int(data.get("extra_ref_image_count") or 0)):
+            warnings.append(
+                "Images on the ref_images socket are not counted here — every <Picture i> "
+                "below shifts up by that batch size when you render.")
         warnings.extend(p.get("ref_warnings") or [])
 
         return web.json_response({

--- a/minimax_media.py
+++ b/minimax_media.py
@@ -264,6 +264,10 @@ async def compile_prompt_endpoint(request):
             "refs": {"images": len(p["ref_image_slots"]),
                      "videos": len(p["ref_video_segs"]),
                      "audios": len(p["ref_audio_segs"])},
+            # slot -> <Subject N>, so the editor's "Voice of" menu can name subjects the way
+            # the prompt does instead of counting slots and getting a different answer
+            "subject_of_slot": {str(k): v for k, v in
+                                (p.get("subject_of_slot") or {}).items()},
             "overridden": bool(p.get("prompt_overridden")),
             # what the timeline would produce, so the panel can offer it back without
             # having to recompile behind the user's back

--- a/minimax_media.py
+++ b/minimax_media.py
@@ -360,11 +360,43 @@ _PROVIDER_DEFAULTS = {
     "custom": {"url": "", "model": ""},
 }
 
-_ANALYZE_PROMPT = (
-    "Describe the character's physical appearance in two concise sentences. "
-    "Specify their hair color/style, face details, and their clothing type/color. "
-    "Keep the entire response very brief."
-)
+# What to look at, per subject kind. A slot is not necessarily a character — the reference
+# guide's <Subject N> covers scenes, props, styles and poses too — and asking for hair and
+# clothing when the image is a coffee shop produced exactly the answer you would expect.
+_ANALYZE_SUBJECT = {
+    "person": ("person", "hair colour and style, face, build, and clothing type and colour"),
+    "animal": ("animal", "species, markings, coat, and build"),
+    "object": ("object", "shape, material, colour, and any markings"),
+    "environment": ("place", "architecture, furnishing, materials, and lighting"),
+    "clothing": ("garment", "cut, colour, material, and fastenings"),
+    "prop": ("prop", "shape, material, colour, and signs of wear"),
+    "interface": ("interface", "layout, typography, iconography, and colour"),
+    "effect": ("visual effect", "shape, colour, motion, and how it interacts with the scene"),
+    "style": ("visual style", "palette, contrast, grain, and grade"),
+    "action": ("action", "the movement, its timing, and the body mechanics"),
+    "expression": ("facial expression", "the eyes, mouth, and what it conveys"),
+    "pose": ("pose", "posture, limb placement, and weight distribution"),
+}
+
+
+def analyze_prompt(kind):
+    """Ask the vision model for the slot's two sentences, in labelled lines.
+
+    Two answers, not one: `DESCRIPTION` becomes the `<Subject N>` definition and
+    `RETAINED` becomes its retention_analysis line. They are different sentences in
+    different sections — one says what the thing is, the other says what has to survive
+    into the generated video — and the guide's own example writes both.
+    """
+    noun, look_for = _ANALYZE_SUBJECT.get(kind or "", _ANALYZE_SUBJECT["person"])
+    return (
+        "Look at the reference image(s) of this %s and answer in exactly two lines, "
+        "using these labels and nothing else:\n"
+        "DESCRIPTION: one concise sentence naming the %s.\n"
+        "RETAINED: a short comma-separated list of the specific features that must stay "
+        "identical in a generated video.\n"
+        "Do not add any other text, headings or commentary."
+        % (noun, look_for)
+    )
 
 
 def normalize_base_url(url, fallback=""):
@@ -489,9 +521,11 @@ async def vlm_generate(images_b64, prompt, provider, base_url, model,
 @PromptServer.instance.routes.post("/minimax_director/analyze_character")
 async def analyze_character_endpoint(request):
     try:
+        from . import minimax_plan as plan
         data = await request.json()
         image_b64 = data.get("image_b64", "")
         char_index = int(data.get("char_index", 0))
+        kind = plan.sanitize_kind(data.get("kind"))
         provider, base_url, model_name = _resolve_provider(data)
 
         if provider == "off":
@@ -504,16 +538,18 @@ async def analyze_character_endpoint(request):
         if not cleaned:
             return web.json_response({"status": "error", "message": "No valid base64 images decoded."})
 
-        log.info("[MiniMaxDirector] Analyzing Character %d via %s (%s, model '%s')...",
-                 char_index + 1, provider, base_url, model_name)
+        log.info("[MiniMaxDirector] Analyzing reference slot %d (%s) via %s (%s, model "
+                 "'%s')...", char_index + 1, kind, provider, base_url, model_name)
         try:
-            generated_text = await vlm_generate(cleaned, _ANALYZE_PROMPT, provider,
+            generated_text = await vlm_generate(cleaned, analyze_prompt(kind), provider,
                                                 base_url, model_name)
         except VLMError as e:
             return web.json_response({"status": "error", "message": str(e)})
 
+        description, retained = plan.split_analysis(generated_text)
         log.info("[MiniMaxDirector] Analysis complete: %s", generated_text)
-        return web.json_response({"status": "success", "description": generated_text})
+        return web.json_response({"status": "success", "description": description,
+                                  "retention_note": retained})
     except Exception as e:
         log.error("[MiniMaxDirector] Failed to analyze character: %s", e)
         return web.json_response({"status": "error", "message": str(e)}, status=500)

--- a/minimax_media.py
+++ b/minimax_media.py
@@ -267,6 +267,75 @@ async def compile_prompt_endpoint(request):
         return web.json_response({"status": "error", "message": str(e)}, status=500)
 
 
+@PromptServer.instance.routes.post("/minimax_director/probe_video")
+async def probe_video_endpoint(request):
+    """Duration, size and a first frame for a video the browser could not open.
+
+    The editor builds a reference-video segment from a local blob: it needs the duration
+    to size the clip on the timeline and a frame for the thumbnail. That path goes through
+    a <video> element, so it only works for what the browser can decode — and a browser
+    decodes far less than the renderer does. HEVC, ProRes and 10-bit footage inside a
+    perfectly ordinary .mp4 or .mov are all refused by Chrome and all read fine here,
+    because PyAV is what loads reference videos at generation time anyway.
+
+    Without this the editor silently rejected files it would have rendered without
+    complaint. The codec is reported back so a failure can at least name itself.
+    """
+    try:
+        data = await request.json()
+        path = resolve_input_path(data.get("file") or "")
+        if not path:
+            return web.json_response({"status": "error",
+                                      "message": "File not found on the server."})
+
+        with av.open(path) as container:
+            if not container.streams.video:
+                return web.json_response({"status": "error",
+                                          "message": "No video stream in that file."})
+            stream = container.streams.video[0]
+            codec = getattr(stream.codec_context, "name", "") or ""
+            width = stream.width or stream.codec_context.width or 0
+            height = stream.height or stream.codec_context.height or 0
+
+            # Container duration first — a stream's own is missing often enough to matter.
+            duration = 0.0
+            if container.duration:
+                duration = float(container.duration) / av.time_base
+            elif stream.duration and stream.time_base:
+                duration = float(stream.duration * stream.time_base)
+
+            rate = stream.average_rate or stream.guessed_rate
+            fps = float(rate) if rate else 0.0
+
+            # Some containers report no duration at all. Frame count over rate is the
+            # fallback, and it has to be read while the container is still open.
+            if duration <= 0 and fps > 0 and stream.frames:
+                duration = float(stream.frames) / fps
+
+            thumb = ""
+            try:
+                frame = next(container.decode(video=0), None)
+                if frame is not None:
+                    image = frame.to_image()
+                    image.thumbnail((512, 512))
+                    buffer = _io.BytesIO()
+                    image.convert("RGB").save(buffer, format="JPEG", quality=90)
+                    thumb = "data:image/jpeg;base64," + \
+                        base64.b64encode(buffer.getvalue()).decode("ascii")
+            except Exception as e:
+                # a thumbnail is a nicety; the clip is still usable without one
+                log.debug("[MiniMaxDirector] probe thumbnail failed for %s: %s", path, e)
+
+        log.info("[MiniMaxDirector] probed '%s': %s %dx%d, %.2fs @ %.2f fps",
+                 os.path.basename(path), codec or "unknown", width, height, duration, fps)
+        return web.json_response({"status": "success", "duration": round(duration, 3),
+                                  "fps": round(fps, 4), "width": width, "height": height,
+                                  "codec": codec, "thumb": thumb})
+    except Exception as e:
+        log.warning("[MiniMaxDirector] probe_video failed: %s", e)
+        return web.json_response({"status": "error", "message": str(e)})
+
+
 @PromptServer.instance.routes.get("/minimax_director_get_audio")
 async def minimax_director_get_audio(request):
     filename = request.query.get("filename")

--- a/minimax_media.py
+++ b/minimax_media.py
@@ -254,6 +254,9 @@ async def compile_prompt_endpoint(request):
             "shots": len(p["shots"]),
             "length": p["length"],
             "seconds": round(p["actual_seconds"], 2),
+            # shown in the badge rather than warned about: the guide's 350-500 is a lot of
+            # words for a 5-15s clip, so being under it is the ordinary state here
+            "words": p.get("description_words") or 0,
             "refs": {"images": len(p["ref_image_slots"]),
                      "videos": len(p["ref_video_segs"]),
                      "audios": len(p["ref_audio_segs"])},

--- a/minimax_plan.py
+++ b/minimax_plan.py
@@ -37,6 +37,82 @@ ROLE_FIRST = "first"
 ROLE_LAST = "last"
 ROLE_MIDDLE = "middle"
 
+# --- the full-reference vocabulary (references/ref-en.txt) ---------------------------
+# The retention markers are "fixed English values in the output format", so they are
+# emitted verbatim and never paraphrased. Whatever the editor sends is clamped back to a
+# default rather than allowed to reach the prompt as an invented word.
+RETENTION_VISIBLE = ("fully_preserved", "partially_preserved",
+                     "attribute_transfer", "weak_reference")
+RETENTION_AUDIO = ("fully_copy", "partially_copy", "reference", "weak_reference")
+# fully_preserved is the right default even for a motion reference: the marker preserves
+# the *defined role* of the content, and a reference video's defined role is its camera
+# work, not its pixels. Audio defaults to `reference` because nothing here copies a
+# signal — the track guides timbre and delivery.
+RETENTION_DEFAULT = "fully_preserved"
+RETENTION_AUDIO_DEFAULT = "reference"
+
+# <Subject N> is not a character slot. The guide lists "people, animals, or objects;
+# scenes, backgrounds, or environments; clothing, props, interfaces, or visual effects;
+# styles, actions, expressions, or poses". The noun is only used when a slot has no
+# description of its own to put there.
+SUBJECT_KINDS = {
+    "person": "the person",
+    "animal": "the animal",
+    "object": "the object",
+    "environment": "the environment",
+    "clothing": "the outfit",
+    "prop": "the prop",
+    "interface": "the interface",
+    "effect": "the visual effect",
+    "style": "the visual style",
+    "action": "the action",
+    "expression": "the expression",
+    "pose": "the pose",
+}
+SUBJECT_KIND_DEFAULT = "person"
+
+# What "retained" means per kind, so a fully_preserved line says something the model can
+# act on instead of repeating the marker back at it. `picture` and `video` are not subject
+# kinds; they share the table because they need the same sentence.
+RETAINED_DETAIL = {
+    "person": "identity, face and clothing",
+    "animal": "markings, coat and build",
+    "object": "shape, colour and markings",
+    "environment": "layout, furnishing and lighting",
+    "clothing": "cut, colour and material",
+    "prop": "shape, colour and wear",
+    "interface": "layout, typography and iconography",
+    "effect": "shape, colour and behaviour",
+    "style": "palette, texture and grade",
+    "action": "timing and body mechanics",
+    "expression": "expression and gaze",
+    "pose": "posture and limb placement",
+    "picture": "framing and composition",
+    "storyboard": "viewpoint, subject placement and shot order",
+    "video": "camera work and motion",
+}
+
+# How a timeline image is used. `auto` keeps the behaviour the timeline already implies —
+# classify_events decides whether it opens, closes or anchors a shot. The other two cover
+# the guide's remaining cases: a shot-planning image, and an image that only *defines*
+# something and therefore earns no standalone <Picture N> entry at all.
+REF_ROLE_AUTO = "auto"
+REF_ROLE_STORYBOARD = "storyboard"
+REF_ROLE_SUBJECT = "subject"
+REF_ROLES = (REF_ROLE_AUTO, REF_ROLE_STORYBOARD, REF_ROLE_SUBJECT)
+
+MAX_SUBJECT_SLOTS = 9
+
+TASK_KEYFRAME = "keyframe completion"
+TASK_REFERENCE = "reference generation"
+TASK_EDITING = "video editing"
+TASK_CONTINUATION = "video continuation"
+TASK_AUDIO_REUSE = "audio reuse"
+TASK_AUDIO_REFERENCE = "audio reference"
+# the guide's own table order, so a combined prefix always reads the same way round
+TASK_ORDER = (TASK_KEYFRAME, TASK_REFERENCE, TASK_EDITING, TASK_CONTINUATION,
+              TASK_AUDIO_REUSE, TASK_AUDIO_REFERENCE)
+
 
 def align_frame_count(n):
     """H3 only accepts frame counts on the 17k+5 grid."""
@@ -54,16 +130,44 @@ def fmt_seconds(value):
 
 
 def substitute_char_tags(text, replacements):
-    """Swap @character1/@char1 .. @character3/@char3 for their resolved text."""
+    """Swap @ref1/@character1/@char1 .. @ref9 for their resolved text.
+
+    A slot is no longer necessarily a character, so @refN is the name that fits what the
+    slots now hold. @characterN/@charN keep working for every slot — prompts written
+    against the old three-slot panel must not break.
+
+    Highest slot first: @ref1 is a prefix of @ref10 today only in spirit, but @char1 *is*
+    a prefix of nothing while @ref1 would be of @ref11 if the cap ever moved. Descending
+    order makes that class of bug impossible rather than merely absent.
+    """
     if not text:
         return text or ""
-    for slot in (1, 2, 3):
+    for slot in range(MAX_SUBJECT_SLOTS, 0, -1):
         value = replacements.get(slot)
         if not value:
             continue
-        for tag in ("@character%d" % slot, "@char%d" % slot):
+        for tag in ("@character%d" % slot, "@char%d" % slot, "@ref%d" % slot):
             text = text.replace(tag, value)
     return text
+
+
+def sanitize_retention(value, audio=False):
+    """Clamp a retention marker to the guide's fixed vocabulary."""
+    allowed = RETENTION_AUDIO if audio else RETENTION_VISIBLE
+    text = str(value or "").strip().lower()
+    if text in allowed:
+        return text
+    return RETENTION_AUDIO_DEFAULT if audio else RETENTION_DEFAULT
+
+
+def sanitize_kind(value):
+    text = str(value or "").strip().lower()
+    return text if text in SUBJECT_KINDS else SUBJECT_KIND_DEFAULT
+
+
+def sanitize_ref_role(value):
+    text = str(value or "").strip().lower()
+    return text if text in REF_ROLES else REF_ROLE_AUTO
 
 
 def overlaps(seg, win_start, win_end):
@@ -121,33 +225,255 @@ def fmt_timestamp(seconds):
     return "%02d:%06.3f" % (minutes, rest)
 
 
-def build_subject_definitions(char_slots, ref_image_slots, ref_video_segs, ref_audio_segs):
-    """Bind <Subject N> names to the <Picture i> labels the tokenizer will emit.
+def retention_note(label, marker, kind=None, audio=False):
+    """The `- …` half of a retention line, for when nothing was written by hand.
 
-    The guide separates <Subject N> (reusable content: a person, a place, a style) from
-    <Picture N> (a concrete frame anchor). ComfyUI's tokenizer only ever labels images
-    <Picture i>, so a subject has to be *defined* in terms of those labels before shots
-    can refer to it — which is exactly what subject_definitions is for.
+    The marker alone is the guide's fixed vocabulary; this is the sentence that says what
+    the marker means *for this particular reference*, so the line carries something the
+    model can act on instead of repeating the marker back at it.
+    """
+    if audio:
+        return {
+            "fully_copy": "%s is reused as the target video's complete final audio track.",
+            "partially_copy": "part of %s is copied; other sounds are added, removed or "
+                              "replaced.",
+            "reference": "the target follows %s without copying the original signal.",
+            "weak_reference": "only a broad similarity to %s in category and atmosphere "
+                              "is kept.",
+        }[marker] % label
+    if marker == "fully_preserved":
+        detail = RETAINED_DETAIL.get(kind or "")
+        if detail:
+            return "the %s of %s are retained." % (detail, label)
+        return "%s is retained as defined." % label
+    return {
+        "partially_preserved": "%s is still used, with some of its defined characteristics "
+                               "changed.",
+        "attribute_transfer": "the characteristics of %s are transferred to a different "
+                              "target subject.",
+        "weak_reference": "only a broad similarity to %s in style, category, composition "
+                          "and atmosphere is kept.",
+    }[marker] % label
+
+
+def picture_texts(ordinal, picture_role, ref_role, shot_no, at):
+    """Every wording a standalone <Picture N> needs, derived once from the job it does.
+
+    Four renderings, because the guide asks for the same fact in four places: the
+    subject_definitions declaration (2.2), the retention_analysis parenthetical (4.1), the
+    in-body phrasing (5.3), and — outside the guide entirely — the flat `Reference notes:`
+    line the comfyui format keeps instead of all of the above.
+
+    Deriving them together is the point: they described the same image in three different
+    voices when the wording lived in three places, which is how issue #4 happened.
+    """
+    label = "<Picture %d>" % ordinal
+    shot = "[Shot %d]" % shot_no if shot_no else ""
+
+    if ref_role == REF_ROLE_STORYBOARD:
+        target = shot or "the target video"
+        return {
+            "declaration": "%s is a storyboard reference for %s, defining its viewpoint, "
+                           "subject placement, and shot order." % (label, target),
+            "where": "storyboard reference for %s" % target,
+            "phrase": "The shot follows the storyboard reference %s." % label if shot else "",
+            "note": "%s is a storyboard reference for %s" % (label, target),
+        }
+    if picture_role == ROLE_FIRST:
+        return {
+            "declaration": "%s is the first frame of %s." % (label, shot or "the target video"),
+            "where": ("%s first frame" % shot) if shot else "first frame",
+            "phrase": ("The shot begins from %s." % label) if shot else "",
+            "note": ("%s begins from %s" % (shot, label)) if shot
+                    else "The video begins from %s" % label,
+        }
+    if picture_role == ROLE_LAST:
+        return {
+            "declaration": "%s is the last frame of %s." % (label, shot or "the target video"),
+            "where": ("%s last frame" % shot) if shot else "last frame",
+            "phrase": ("The shot ends on %s." % label) if shot else "",
+            "note": ("%s ends on %s" % (shot, label)) if shot
+                    else "The video ends on %s" % label,
+        }
+    if shot:
+        return {
+            "declaration": "%s is a keyframe of %s, at %s." % (label, shot, at),
+            "where": "%s keyframe at %s" % (shot, at),
+            "phrase": "The shot's keyframe corresponds to %s." % label,
+            "note": "The keyframe of %s corresponds to %s, at %s" % (shot, label, at),
+        }
+    return {
+        "declaration": "%s is a composition anchor at %s." % (label, at),
+        "where": "composition anchor at %s" % at,
+        "phrase": "",
+        "note": "%s is a composition anchor at %s" % (label, at),
+    }
+
+
+def _subject_sentence(label, description, kind, pictures):
+    """`<Subject 1> is a woman in a red coat, shown in <Picture 1>.`
+
+    The guide's own shape is "<Subject 1> is the young woman in <Picture 1>, with long
+    dark hair…" — description first, source second. A written description replaces the
+    kind noun entirely, which is what makes the kind dropdown a fallback rather than a
+    constraint.
+    """
+    text = (description or "").strip().rstrip(".")
+    if text:
+        return "%s is %s, shown in %s." % (label, text, pictures)
+    return "%s is %s shown in %s." % (label, SUBJECT_KINDS[kind], pictures)
+
+
+def build_subject_definitions(subject_slots, ref_image_slots, ref_video_segs,
+                              ref_audio_segs):
+    """Declare every reference label, and record what each needs in retention_analysis.
+
+    The guide's central rule about images lives here: an image only earns a standalone
+    <Picture N> entry when it *is* a frame — "a shot's first frame, keyframe, last frame,
+    edited keyframe, or composition anchor" — or a storyboard reference. An image that
+    merely defines a character, scene, costume or style is cited inside the corresponding
+    <Subject N> definition instead. ComfyUI's tokenizer still labels every image
+    <Picture i>, so this is about which labels get *declared*, not which exist.
+
+    Returns (lines, subject_of_slot, labels, pic_texts). `labels` is the ledger
+    build_retention_analysis walks; `pic_texts` is keyed by <Picture N> ordinal.
     """
     lines = []
+    labels = []
     subject_of_slot = {}
-    for slot_index, _slot in enumerate(char_slots):
+    pic_texts = {}
+    subject_no = 0
+
+    # --- <Subject N>: the panel slots first, so a subject's number does not move when
+    # something is dropped on the timeline
+    for slot_index, slot in enumerate(subject_slots):
         ordinals = [i + 1 for i, s in enumerate(ref_image_slots)
                     if s.get("source") == "char" and s.get("slot") == slot_index]
         if not ordinals:
             continue
-        subject = len(subject_of_slot) + 1
-        subject_of_slot[slot_index + 1] = subject
-        pictures = " and ".join("<Picture %d>" % o for o in ordinals)
-        lines.append("<Subject %d> is the character shown in %s." % (subject, pictures))
+        subject_no += 1
+        subject_of_slot[slot_index + 1] = subject_no
+        label = "<Subject %d>" % subject_no
+        lines.append(_subject_sentence(
+            label, slot.get("description"), slot["kind"],
+            " and ".join("<Picture %d>" % o for o in ordinals)))
+        labels.append({"label": label, "marker": slot["retention"], "kind": slot["kind"],
+                       "note": slot.get("note", ""), "where": "", "audio": False,
+                       "subject": subject_no})
 
-    for i, _seg in enumerate(ref_video_segs):
-        lines.append("<Video %d> is a reference video: follow its motion and camera work."
-                     % (i + 1))
-    for i, _seg in enumerate(ref_audio_segs):
-        lines.append("<Audio %d> is a reference audio clip: follow its voice and timbre."
-                     % (i + 1))
-    return lines, subject_of_slot
+    # ...then any timeline image the user marked as defining something rather than
+    # anchoring a frame. It gets a subject of its own and no picture entry.
+    for i, s in enumerate(ref_image_slots):
+        if s.get("source") != "timeline" or s.get("ref_role") != REF_ROLE_SUBJECT:
+            continue
+        subject_no += 1
+        label = "<Subject %d>" % subject_no
+        s["subject"] = subject_no
+        lines.append(_subject_sentence(label, s.get("note"), s["kind"],
+                                       "<Picture %d>" % (i + 1)))
+        labels.append({"label": label, "marker": s["retention"], "kind": s["kind"],
+                       "note": "", "where": "", "audio": False, "subject": subject_no})
+
+    # --- <Picture N>: only the real frame and storyboard anchors.
+    # Character-slot images are deliberately absent — they are cited above instead. So are
+    # images arriving on the ref_images socket: the node knows nothing about them beyond
+    # the pixels, and a vacuous "is an additional reference image" line would cost the
+    # model attention without telling it anything.
+    for i, s in enumerate(ref_image_slots):
+        if s.get("source") != "timeline" or s.get("ref_role") == REF_ROLE_SUBJECT:
+            continue
+        ordinal = i + 1
+        texts = picture_texts(ordinal, s.get("picture_role"), s.get("ref_role"),
+                              s.get("shot_no"), s.get("at"))
+        pic_texts[ordinal] = texts
+        lines.append(texts["declaration"])
+        labels.append({"label": "<Picture %d>" % ordinal, "marker": s["retention"],
+                       "kind": "storyboard" if s.get("ref_role") == REF_ROLE_STORYBOARD
+                               else "picture",
+                       "note": s.get("note", ""),
+                       "where": texts["where"], "audio": False})
+
+    for i, seg in enumerate(ref_video_segs):
+        label = "<Video %d>" % (i + 1)
+        lines.append("%s is a reference video: follow its motion and camera work." % label)
+        labels.append({"label": label, "kind": "video", "audio": False,
+                       "marker": sanitize_retention(seg.get("retention")),
+                       "note": (seg.get("refNote") or "").strip(),
+                       "where": "motion and camera work"})
+    for i, seg in enumerate(ref_audio_segs):
+        label = "<Audio %d>" % (i + 1)
+        marker = sanitize_retention(seg.get("retention"), audio=True)
+        # the declaration has to agree with the marker: telling the model to follow a
+        # clip's timbre while retention_analysis says the signal is copied wholesale
+        # describes two different jobs
+        lines.append("%s is a reference audio clip: %s"
+                     % (label, "its signal is reused in the target video."
+                        if marker in ("fully_copy", "partially_copy")
+                        else "follow its voice and timbre."))
+        labels.append({"label": label, "kind": "audio", "audio": True, "marker": marker,
+                       "note": (seg.get("refNote") or "").strip(), "where": ""})
+
+    return lines, subject_of_slot, labels, pic_texts
+
+
+def build_retention_analysis(labels, subject_shots=None):
+    """One line per reference label, in the guide's `label (where): marker - note` shape.
+
+    A subject's parenthetical names the shots it actually appears in, read back off the
+    shot text after tag substitution rather than assumed — a subject defined in the panel
+    but never mentioned in any shot simply has no shot list to give.
+    """
+    subject_shots = subject_shots or {}
+    lines = []
+    for entry in labels:
+        where = entry.get("where") or ""
+        if entry.get("subject"):
+            shots = subject_shots.get(entry["subject"]) or []
+            if shots:
+                where = "appears in " + ", ".join("[Shot %d]" % n for n in shots)
+        note = (entry.get("note") or "").strip()
+        if note:
+            if not note.endswith((".", "!", "?")):
+                note += "."
+        else:
+            note = retention_note(entry["label"], entry["marker"], entry.get("kind"),
+                                  entry.get("audio", False))
+        head = "%s (%s)" % (entry["label"], where) if where else entry["label"]
+        lines.append("%s: %s - %s" % (head, entry["marker"], note))
+    return lines
+
+
+def task_type_prefix(ref_image_slots, ref_video_segs, ref_audio_segs, override=None):
+    """The square-bracketed task type the guide puts at the head of `summary`.
+
+    Derived from the jobs the references actually do, not from what happens to be
+    connected: the guide is explicit that "the mere presence of video or audio does not
+    automatically create a corresponding task type", and that a reference video supplying
+    only camera movement, cuts or rhythm is reference generation, not video editing.
+
+    `video editing` and `video continuation` are therefore never derived — this node has
+    no path that edits or continues a source video. The override exists for the day one
+    is added, and for anything else the timeline cannot know.
+    """
+    if (override or "").strip():
+        return "[%s]" % override.strip().strip("[]").strip()
+
+    types = set()
+    for s in ref_image_slots:
+        if s.get("source") == "timeline" and s.get("ref_role") == REF_ROLE_AUTO:
+            types.add(TASK_KEYFRAME)
+        else:
+            types.add(TASK_REFERENCE)
+    if ref_video_segs:
+        types.add(TASK_REFERENCE)
+    for seg in ref_audio_segs:
+        types.add(TASK_AUDIO_REUSE
+                  if sanitize_retention(seg.get("retention"), audio=True)
+                  in ("fully_copy", "partially_copy")
+                  else TASK_AUDIO_REFERENCE)
+
+    ordered = [t for t in TASK_ORDER if t in types]
+    return ("[%s]" % " + ".join(ordered)) if ordered else ""
 
 
 def alignment_instruction(has_first, has_last, shot_count, seconds):
@@ -187,13 +513,19 @@ def alignment_instruction(has_first, has_last, shot_count, seconds):
 
 def compile_storyboard_minimax(global_prompt, shots, soundscape="", music="",
                                subject_lines=None, retention_lines=None,
-                               instruction=""):
+                               instruction="", summary=""):
     """The notation MiniMax documents in VIDEO_PROMPT_WRITING_GUIDE_*.md.
 
     `integrated_multimodal_description: [Shot 1] … [Shot 2] At 00:05.000, …`, with the
     first shot carrying no timestamp and every later cut carrying a strictly increasing
     one, followed by the soundscape fields. Sections are only emitted when there is
     something real to put in them — an empty heading is worse than none.
+
+    Section order is the reference guide's: subject_definitions, summary,
+    retention_analysis, detailed_description, then the two sound fields.
+    retention_analysis is the one section written one entry per line, because its entries
+    are `label (where): marker - note` records rather than prose, and running them
+    together makes the markers hard to pick out.
     """
     parts = []
 
@@ -204,8 +536,10 @@ def compile_storyboard_minimax(global_prompt, shots, soundscape="", music="",
 
     if subject_lines:
         parts.append("subject_definitions: " + " ".join(subject_lines))
+    if (summary or "").strip():
+        parts.append("summary: " + summary.strip())
     if retention_lines:
-        parts.append("retention_analysis: " + " ".join(retention_lines))
+        parts.append("retention_analysis:\n" + "\n".join(retention_lines))
 
     written = [s for s in shots if (s["prompt"] or "").strip()]
     body = []
@@ -214,6 +548,15 @@ def compile_storyboard_minimax(global_prompt, shots, soundscape="", music="",
         body.append(gp)
     for index, shot in enumerate(written):
         text = shot["prompt"].strip()
+        # guide 5.3: a frame anchor is named in the shot itself, in natural phrasing, as
+        # well as being declared above. It goes after the shot's own text: a later shot
+        # opens "At 00:05.000, " and the sentence has to continue out of that comma, which
+        # a capitalised "The shot begins from…" cannot do.
+        phrases = " ".join(shot.get("ref_phrases") or [])
+        if phrases:
+            if not text.endswith((".", "!", "?", ",", ";", ":")):
+                text += "."
+            text = "%s %s" % (text, phrases)
         if index == 0:
             body.append("[Shot 1] %s" % text)
         else:
@@ -323,7 +666,8 @@ def classify_events(events, duration_frames, fps):
 
 def plan_timeline(tdata, win_start, duration_frames, fps, global_prompt="",
                   use_custom_motion=True, use_custom_audio=False, override_audio=False,
-                  extra_ref_image_count=0, soundscape="", music="", prompt_format=None):
+                  extra_ref_image_count=0, soundscape="", music="", prompt_format=None,
+                  summary=""):
     """Work out shots, keyframe roles, reference ordinals and the final prompt.
 
     Returns a dict; `execute` uses it to decide what media to load, the endpoint just
@@ -353,15 +697,26 @@ def plan_timeline(tdata, win_start, duration_frames, fps, global_prompt="",
     if prompt_format not in (FORMAT_MINIMAX, FORMAT_COMFYUI):
         prompt_format = FORMAT_MINIMAX
 
-    # --- character slots (metadata only) ---
-    char_slots = []          # [{"count": n, "images": [{"b64","name"}], "description": str}]
-    for char_info in tdata.get("characters", []) or []:
-        images_list = char_info.get("images", []) or []
-        legacy_b64 = char_info.get("imageB64", "")
+    # --- subject slots (metadata only) ---
+    # `subjects` is what the editor writes now; `characters` is the same panel's old key
+    # and is still read, because a slot holding a scene or a prop is the same structure
+    # that used to hold only characters.
+    subject_slots = []
+    raw_slots = tdata.get("subjects")
+    if not isinstance(raw_slots, list):
+        raw_slots = tdata.get("characters", []) or []
+    for info in raw_slots[:MAX_SUBJECT_SLOTS]:
+        images_list = info.get("images", []) or []
+        legacy_b64 = info.get("imageB64", "")
         if legacy_b64 and not images_list:
-            images_list = [{"b64": legacy_b64, "name": char_info.get("fileName", "")}]
-        char_slots.append({"images": images_list,
-                           "description": char_info.get("description", "") or ""})
+            images_list = [{"b64": legacy_b64, "name": info.get("fileName", "")}]
+        subject_slots.append({
+            "images": images_list,
+            "description": info.get("description", "") or "",
+            "kind": sanitize_kind(info.get("kind")),
+            "retention": sanitize_retention(info.get("retention")),
+            "note": info.get("retentionNote", "") or "",
+        })
 
     # --- shots + image events ---
     shots, events = [], []
@@ -408,15 +763,13 @@ def plan_timeline(tdata, win_start, duration_frames, fps, global_prompt="",
     ref_image_slots = []     # {"source": "char"/"input"/"timeline", ...} in <Picture i> order
 
     if ref_mode_on:
-        for slot_idx, slot in enumerate(char_slots):
+        for slot_idx, slot in enumerate(subject_slots):
             if not slot["images"] or len(ref_image_slots) >= MAX_REF_IMAGES:
                 continue
-            char_tag_values[slot_idx + 1] = "<Picture %d>" % (len(ref_image_slots) + 1)
             for img in slot["images"]:
                 if len(ref_image_slots) >= MAX_REF_IMAGES:
                     break
                 ref_image_slots.append({"source": "char", "slot": slot_idx, "image": img})
-                ref_image_slots[-1]["slot"] = slot_idx
 
         for _ in range(max(0, int(extra_ref_image_count))):
             if len(ref_image_slots) >= MAX_REF_IMAGES:
@@ -443,9 +796,16 @@ def plan_timeline(tdata, win_start, duration_frames, fps, global_prompt="",
         # text. An image whose own segment has no prompt gets the guide's shot-free
         # phrasing rather than a number the reader cannot find.
         #
-        # The role also lives on the slot, where it is not about wording at all: it picks
-        # which frame of a *video* segment becomes the reference (the last one for
-        # ROLE_LAST) and whether it is fitted to the canvas. See minimax_director.py.
+        # Only what the wording will be *derived from* is recorded here. The sentences
+        # themselves are built after the total-file cap has trimmed the list, so a
+        # reference that did not survive never had a note to prune — the old code wrote
+        # the notes first and then parsed the strings back apart to drop them again.
+        #
+        # `picture_role` is the timeline's own reading of the image (opening, closing or
+        # in between); `ref_role` is what the user says the image is *for*. Only an
+        # untouched `auto` image is a real keyframe: that flag is not about wording at all,
+        # it picks which frame of a video segment becomes the reference and whether it is
+        # fitted to the canvas. See minimax_director.py.
         written_shot_no = {}
         counted = 0
         for shot_i, shot in enumerate(shots):
@@ -456,28 +816,20 @@ def plan_timeline(tdata, win_start, duration_frames, fps, global_prompt="",
         for ev in events:
             if len(ref_image_slots) >= MAX_REF_IMAGES:
                 break
-            ordinal = len(ref_image_slots) + 1
-            slot = {"source": "timeline", "event": ev}
-            if ev["role"] in (ROLE_FIRST, ROLE_LAST):
+            seg = ev["seg"]
+            ref_role = sanitize_ref_role(seg.get("refRole"))
+            slot = {"source": "timeline", "event": ev, "ref_role": ref_role,
+                    "picture_role": ev["role"],
+                    "kind": sanitize_kind(seg.get("refKind")),
+                    "retention": sanitize_retention(seg.get("retention")),
+                    "note": (seg.get("refNote") or "").strip(),
+                    "shot_no": written_shot_no.get(ev.get("shot_index")),
+                    "at": fmt_seconds(ev["rel_start_f"] / fps)}
+            if ref_role == REF_ROLE_AUTO and ev["role"] in (ROLE_FIRST, ROLE_LAST):
                 slot["keyframe"] = ev["role"]
-            shot_no = written_shot_no.get(ev.get("shot_index"))
-            at = fmt_seconds(ev["rel_start_f"] / fps)
-            if ev["role"] == ROLE_FIRST:
-                ref_notes.append("[Shot %d] begins from <Picture %d>" % (shot_no, ordinal)
-                                 if shot_no else
-                                 "The video begins from <Picture %d>" % ordinal)
-            elif ev["role"] == ROLE_LAST:
-                ref_notes.append("[Shot %d] ends on <Picture %d>" % (shot_no, ordinal)
-                                 if shot_no else
-                                 "The video ends on <Picture %d>" % ordinal)
-            else:
-                ref_notes.append(
-                    "The keyframe of [Shot %d] corresponds to <Picture %d>, at %s"
-                    % (shot_no, ordinal, at) if shot_no else
-                    "<Picture %d> is a composition anchor at %s" % (ordinal, at))
             ref_image_slots.append(slot)
     else:
-        for slot_idx, slot in enumerate(char_slots):
+        for slot_idx, slot in enumerate(subject_slots):
             if slot["description"]:
                 char_tag_values[slot_idx + 1] = slot["description"]
 
@@ -511,11 +863,6 @@ def plan_timeline(tdata, win_start, duration_frames, fps, global_prompt="",
         ref_warnings.append(
             "H3 takes at most %d reference files in total; %d were dropped."
             % (MAX_REF_FILES, total_files - MAX_REF_FILES))
-        # drop the notes for every picture that was trimmed, not just the first one
-        kept_pictures = len(ref_image_slots)
-        ref_notes = [n for n in ref_notes
-                     if not (n.startswith("<Picture ")
-                             and int(n[9:n.index(">")]) > kept_pictures)]
 
     # reference videos: each 2-15s, and no more than 15s of them together
     if ref_video_segs:
@@ -545,14 +892,33 @@ def plan_timeline(tdata, win_start, duration_frames, fps, global_prompt="",
     length = align_frame_count(max(5, int(round(window_seconds * MODEL_FPS))))
     actual_seconds = length / MODEL_FPS
 
-    # --- prompt ---
-    subject_lines, subject_of_slot = [], {}
-    if ref_mode_on and prompt_format == FORMAT_MINIMAX:
-        subject_lines, subject_of_slot = build_subject_definitions(
-            char_slots, ref_image_slots, ref_video_segs, ref_audio_segs)
-        # a named subject beats a bare picture label: it survives across cuts
-        for slot, subject in subject_of_slot.items():
-            char_tag_values[slot] = "<Subject %d>" % subject
+    # --- reference labels ---
+    # Built after the caps have done their trimming, so every declaration describes a
+    # reference that is actually being sent.
+    subject_lines, subject_of_slot, ref_labels, pic_texts = [], {}, [], {}
+    if ref_mode_on:
+        subject_lines, subject_of_slot, ref_labels, pic_texts = build_subject_definitions(
+            subject_slots, ref_image_slots, ref_video_segs, ref_audio_segs)
+        # the comfyui format has no sections to put any of this in, so it keeps the one
+        # flat notes line — which is the same set of facts in the guide's older phrasing
+        ref_notes = [pic_texts[o]["note"] for o in sorted(pic_texts)]
+
+        # A slot whose pictures were all trimmed away must not keep pointing at an ordinal
+        # that no longer exists; it falls back to its description, exactly as it would
+        # with references off.
+        char_tag_values = {}
+        for slot_index, slot in enumerate(subject_slots):
+            ordinals = [i + 1 for i, s in enumerate(ref_image_slots)
+                        if s.get("source") == "char" and s.get("slot") == slot_index]
+            if ordinals:
+                char_tag_values[slot_index + 1] = "<Picture %d>" % ordinals[0]
+            elif slot["description"]:
+                char_tag_values[slot_index + 1] = slot["description"]
+
+        if prompt_format == FORMAT_MINIMAX:
+            # a named subject beats a bare picture label: it survives across cuts
+            for slot, subject in subject_of_slot.items():
+                char_tag_values[slot] = "<Subject %d>" % subject
 
     global_prompt = substitute_char_tags(global_prompt, char_tag_values)
     for shot in shots:
@@ -571,23 +937,37 @@ def plan_timeline(tdata, win_start, duration_frames, fps, global_prompt="",
                          "Audio:" if label == "overall_soundscape" else "Music:")
         soundscape = (soundscape or "").strip() or found_audio
         music = (music or "").strip() or found_music
-        retention_lines = []
-        if subject_lines:
-            named = ", ".join("<Subject %d>" % s for s in sorted(subject_of_slot.values()))
-            if named:
-                retention_lines.append(
-                    "Keep the identity, face and clothing of %s consistent across every shot."
-                    % named)
-            if ref_video_segs:
-                retention_lines.append(
-                    "Follow the camera work and motion of %s."
-                    % ", ".join("<Video %d>" % (i + 1) for i in range(len(ref_video_segs))))
-            if ref_audio_segs:
-                retention_lines.append(
-                    "Keep the voice and timbre of %s."
-                    % ", ".join("<Audio %d>" % (i + 1) for i in range(len(ref_audio_segs))))
-        if ref_notes:
-            retention_lines.extend(n + "." for n in ref_notes)
+
+        # Which shots each subject actually turns up in, read back off the shot text now
+        # that the tags have been substituted. Numbering matches the body, which counts
+        # only shots carrying text.
+        subject_shots = {}
+        written_no = 0
+        for shot in shots:
+            if not (shot["prompt"] or "").strip():
+                continue
+            written_no += 1
+            for entry in ref_labels:
+                num = entry.get("subject")
+                if num and entry["label"] in shot["prompt"]:
+                    subject_shots.setdefault(num, []).append(written_no)
+
+        retention_lines = build_retention_analysis(ref_labels, subject_shots)
+
+        # guide 5.3: name the frame anchor inside the shot as well as declaring it above
+        for ordinal, texts in pic_texts.items():
+            if not texts["phrase"]:
+                continue
+            shot_index = ref_image_slots[ordinal - 1]["event"].get("shot_index")
+            if shot_index is not None and 0 <= shot_index < len(shots):
+                shots[shot_index].setdefault("ref_phrases", []).append(texts["phrase"])
+
+        summary_line = " ".join(x for x in (
+            task_type_prefix(ref_image_slots, ref_video_segs, ref_audio_segs,
+                             tdata.get("task_type_override")) if ref_mode_on else "",
+            (summary or "").strip() or (tdata.get("summary", "") or "").strip(),
+        ) if x)
+
         # Only the fl2va path: ref2va has no keyframe slot and its guide asks for no
         # instruction line. `written` mirrors the shot numbering the body will use.
         instruction = ""
@@ -598,7 +978,8 @@ def plan_timeline(tdata, win_start, duration_frames, fps, global_prompt="",
                 any(e["role"] == ROLE_LAST for e in events),
                 written_shots, actual_seconds)
         prompt = compile_storyboard_minimax(global_prompt, shots, soundscape, music,
-                                            subject_lines, retention_lines, instruction)
+                                            subject_lines, retention_lines, instruction,
+                                            summary_line)
     else:
         prompt = compile_storyboard(global_prompt, shots, window_seconds)
         if ref_notes:

--- a/minimax_plan.py
+++ b/minimax_plan.py
@@ -1450,6 +1450,11 @@ def plan_timeline(tdata, win_start, duration_frames, fps, global_prompt="",
         "prompt_overridden": overridden, "compiled_prompt": compiled_prompt,
         "shots": shots, "events": events, "retake": retake,
         "ref_mode_on": ref_mode_on, "mode": mode,
+        # Which panel slot became which <Subject N>, keyed by 1-based slot. Not the slot
+        # number: only slots that hand over a reference image are numbered, so slot 2 is
+        # <Subject 1> when slot 1 is empty. The editor needs the answer to label its own
+        # menus, and working it out there would be a second copy of this rule.
+        "subject_of_slot": subject_of_slot,
         "ref_image_slots": ref_image_slots, "ref_notes": ref_notes,
         "ref_video_segs": ref_video_segs, "ref_audio_segs": ref_audio_segs,
         "ref_warnings": ref_warnings, "prompt_format": prompt_format,

--- a/minimax_plan.py
+++ b/minimax_plan.py
@@ -1266,17 +1266,30 @@ def plan_timeline(tdata, win_start, duration_frames, fps, global_prompt="",
             for slot, subject in subject_of_slot.items():
                 char_tag_values[slot] = "<Subject %d>" % subject
 
-    # Left to right through the finished video — the global block, then each shot in turn,
-    # its prose before its dialogue. `seen_slots` is what makes "the first appearance"
-    # mean the first one anywhere rather than the first one in this particular string:
-    # a subject that speaks in shot 1 and is described in shot 2 is introduced by its
-    # spoken line, not re-introduced afterwards.
+    # Left to right through the finished video — `summary`, then the global block, then
+    # each shot in turn, its prose before its dialogue. `seen_slots` is what makes "the
+    # first appearance" mean the first one anywhere rather than the first one in this
+    # particular string: a subject that speaks in shot 1 and is described in shot 2 is
+    # introduced by its spoken line, not re-introduced afterwards.
     #
     # Speakers are numbered in the same pass, which also has to happen after the tags
     # resolve to their labels and before the shot text is read back for
     # `(appears in [Shot N])` — a subject that only ever speaks still appears in the
     # shots where it speaks.
     seen_slots = set()
+
+    # `summary` is a box like any other, so a tag typed in it has to resolve like any
+    # other — it reached the model as a literal "@ref1" before this. It goes first because
+    # the guide's section order puts it above detailed_description, which is what "first
+    # appearance" has to mean here. Only ref2va emits the section: substituting it on the
+    # fl2va path would mark a slot as already introduced on the strength of a sentence
+    # that never gets written out, and the global prompt would then open with a short name
+    # for someone nothing had named yet.
+    summary_text = (summary or "").strip() or (tdata.get("summary", "") or "").strip()
+    if ref_mode_on:
+        summary_text = substitute_char_tags(summary_text, char_tag_values, char_tag_later,
+                                            seen_slots)
+
     global_prompt = substitute_char_tags(global_prompt, char_tag_values, char_tag_later,
                                          seen_slots)
 
@@ -1354,7 +1367,7 @@ def plan_timeline(tdata, win_start, duration_frames, fps, global_prompt="",
             summary_line = " ".join(x for x in (
                 task_type_prefix(ref_image_slots, ref_video_segs, ref_audio_segs,
                                  tdata.get("task_type_override")),
-                (summary or "").strip() or (tdata.get("summary", "") or "").strip(),
+                summary_text,
             ) if x)
 
         # Only the fl2va path: ref2va has no keyframe slot and its guide asks for no

--- a/minimax_plan.py
+++ b/minimax_plan.py
@@ -15,6 +15,7 @@ actually sent would be worse than no preview.
 
 import json
 import logging
+import re
 
 log = logging.getLogger(__name__)
 
@@ -574,7 +575,7 @@ def compile_storyboard_minimax(global_prompt, shots, soundscape="", music="",
     if retention_lines:
         parts.append("retention_analysis:\n" + "\n".join(retention_lines))
 
-    written = [s for s in shots if (s["prompt"] or "").strip()]
+    written = [s for s in shots if shot_has_text(s)]
     body = []
     gp = (global_prompt or "").strip()
     if gp:
@@ -587,9 +588,23 @@ def compile_storyboard_minimax(global_prompt, shots, soundscape="", music="",
         # a capitalised "The shot begins from…" cannot do.
         phrases = " ".join(shot.get("ref_phrases") or [])
         if phrases:
-            if not text.endswith((".", "!", "?", ",", ";", ":")):
+            if text:
+                if not text.endswith((".", "!", "?", ",", ";", ":")):
+                    text += "."
+                text = "%s %s" % (text, phrases)
+            elif index:
+                # nothing of the user's own to open on, and a later shot opens
+                # "At 00:05.000, " — so our own sentence has to continue out of that comma
+                text = phrases[0].lower() + phrases[1:]
+            else:
+                text = phrases
+        # the guide's example ends a shot on its spoken line, after the action that
+        # motivates it
+        spoken = (shot.get("dialogue_text") or "").strip()
+        if spoken:
+            if text and not text.endswith((".", "!", "?")):
                 text += "."
-            text = "%s %s" % (text, phrases)
+            text = ("%s %s" % (text, spoken)).strip()
         if index == 0:
             body.append("[Shot 1] %s" % text)
         else:
@@ -643,6 +658,101 @@ def split_audio_music(text):
         if stripped:
             current.append(stripped)
     return "\n".join(kept).strip(), " ".join(sound).strip(), " ".join(music).strip()
+
+
+# A dialogue line in a shot prompt. Same rule as split_audio_music: it only counts at the
+# start of a line, so prose that merely contains an @ref tag or a colon is left alone.
+#
+#   @ref1 exclaims with light annoyance: Hey! Watch your dog!
+#   @ref1 [French] murmure: Bonjour
+#   @voice(a low male narrator) says: In the beginning...
+#   @audio2: the chorus line carried by the track itself
+#
+# The clause between the tag and the colon is the delivery, kept verbatim — the guide's own
+# example carries the performance there ("says in a casual young male voice with a playful
+# tone"), and generating a flat "says" would throw that away.
+DIALOGUE_RE = re.compile(
+    r"^@(?:ref(?P<slot>\d+)|voice\((?P<voice>[^)]*)\)|audio(?P<audio>\d+))"
+    r"\s*(?:\[(?P<lang>[^\]]+)\])?"
+    r"\s*(?P<delivery>[^:]*):\s*(?P<line>.+)$", re.IGNORECASE)
+
+DIALOGUE_DEFAULT_LANG = "English"
+DIALOGUE_DEFAULT_DELIVERY = "says"
+
+SPEAKER_ID_RE = re.compile(r"\(S\d+\)")
+
+# "Generation tasks typically span 350-500 words". The floor is only worth mentioning once
+# a timeline is a real storyboard — firing it on a two-shot test would be noise, and the
+# guide itself warns against "mechanical word-count adherence".
+DESCRIPTION_MIN_WORDS = 350
+DESCRIPTION_MAX_WORDS = 500
+DESCRIPTION_MIN_SHOTS = 3
+
+
+def split_dialogue(text):
+    """Lift `@ref1 says: …` lines out of a shot prompt into structured vocal events.
+
+    Returns (remaining prose, events). Speaker IDs are deliberately *not* assigned here:
+    the guide numbers them "according to the order of actual vocal events in the target
+    video", which is a property of the whole timeline, not of one shot.
+    """
+    if not text:
+        return text or "", []
+    kept, events = [], []
+    for line in text.splitlines():
+        match = DIALOGUE_RE.match(line.strip())
+        if not match:
+            kept.append(line)
+            continue
+        events.append({
+            "slot": int(match.group("slot")) if match.group("slot") else None,
+            "voice": (match.group("voice") or "").strip() or None,
+            "audio": int(match.group("audio")) if match.group("audio") else None,
+            "language": (match.group("lang") or DIALOGUE_DEFAULT_LANG).strip(),
+            "delivery": (match.group("delivery") or "").strip() or DIALOGUE_DEFAULT_DELIVERY,
+            "line": match.group("line").strip(),
+        })
+    return "\n".join(kept).strip(), events
+
+
+def shot_has_text(shot):
+    """Does this shot appear in the body, and therefore carry a [Shot N] number?
+
+    A shot whose only content is dialogue still counts. Testing the prompt alone would
+    drop it from the body once the dialogue was lifted out — losing the line and shifting
+    every later shot number, including the ones picture notes point at.
+    """
+    return bool((shot.get("prompt") or "").strip() or shot.get("dialogue"))
+
+
+def assign_speakers(shots, label_for_slot):
+    """Number speakers across the timeline and render each line the way the guide asks.
+
+    `(Sx)` is assigned once per speaker, in the order vocal events actually occur, and
+    reused at every later event by that speaker — so the same person keeps one ID across
+    cuts, exactly as <Subject N> does. Verbal content carried by reused audio names
+    <Audio N> as its source and gets no ID at all: the guide is explicit that a cue inside
+    a soundtrack has no independent vocal source to number.
+    """
+    ids = {}
+    for shot in shots:
+        rendered = []
+        for event in shot.get("dialogue") or []:
+            tag = "<d>[%s] %s</d>" % (event["language"], event["line"])
+            if event["audio"]:
+                rendered.append("<Audio %d> carries %s" % (event["audio"], tag))
+                continue
+            if event["slot"]:
+                who = label_for_slot(event["slot"]) or "an unnamed speaker"
+                key = ("slot", event["slot"])
+            else:
+                who = event["voice"] or "an unnamed speaker"
+                key = ("voice", who.strip().lower())
+            if key not in ids:
+                ids[key] = len(ids) + 1
+            rendered.append("%s (S%d) %s, %s" % (who, ids[key], event["delivery"], tag))
+        shot["dialogue_text"] = " ".join(rendered)
+    return ids
 
 
 ANALYSIS_DESC_PREFIX = "description:"
@@ -700,7 +810,13 @@ def split_analysis(text):
 
 def compile_storyboard(global_prompt, shots, total_seconds):
     """Global block, then timed shot lines in the ComfyUI templates' `[0s-1.5s]` notation."""
-    written = [s for s in shots if (s["prompt"] or "").strip()]
+    written = [s for s in shots if shot_has_text(s)]
+
+    # Dialogue was lifted out of the prompt before this format ever saw it, so it has to be
+    # put back or a spoken line would vanish from a comfyui-format prompt entirely.
+    def body(shot):
+        parts = [(shot["prompt"] or "").strip(), (shot.get("dialogue_text") or "").strip()]
+        return " ".join(p for p in parts if p)
 
     parts = []
     gp = (global_prompt or "").strip()
@@ -711,11 +827,10 @@ def compile_storyboard(global_prompt, shots, total_seconds):
             written[0]["end_sec"] >= total_seconds - 0.01:
         # One shot covering the whole window is just a prompt — wrapping it in
         # storyboard syntax would imply a cut that isn't there.
-        parts.append(written[0]["prompt"].strip())
+        parts.append(body(written[0]))
     elif written:
         parts.append("Timeline:\n" + "\n".join(
-            "[%s-%s] %s" % (fmt_seconds(s["start_sec"]), fmt_seconds(s["end_sec"]),
-                            s["prompt"].strip())
+            "[%s-%s] %s" % (fmt_seconds(s["start_sec"]), fmt_seconds(s["end_sec"]), body(s))
             for s in written))
 
     return "\n\n".join(parts).strip()
@@ -816,7 +931,9 @@ def plan_timeline(tdata, win_start, duration_frames, fps, global_prompt="",
                 if overlaps(seg, win_start, win_end) and (seg.get("prompt") or "").strip():
                     text = seg["prompt"]
                     break
-        shots.append({"prompt": text, "start_sec": 0.0, "end_sec": window_seconds})
+        text, spoken = split_dialogue(text)
+        shots.append({"prompt": text, "dialogue": spoken,
+                      "start_sec": 0.0, "end_sec": window_seconds})
     else:
         segments = [s for s in (tdata.get("segments", []) or [])
                     if overlaps(s, win_start, win_end)]
@@ -826,7 +943,10 @@ def plan_timeline(tdata, win_start, duration_frames, fps, global_prompt="",
             seg_len = float(seg.get("length", 1))
             rel_start = max(0.0, seg_start - win_start)
             rel_end = min(float(duration_frames), seg_start + seg_len - win_start)
-            shots.append({"prompt": seg.get("prompt", "") or "",
+            # dialogue is lifted before anything else touches the text, so a shot
+            # whose whole content is a spoken line still becomes a numbered shot
+            prose, spoken = split_dialogue(seg.get("prompt", "") or "")
+            shots.append({"prompt": prose, "dialogue": spoken,
                           "start_sec": rel_start / fps, "end_sec": rel_end / fps})
 
             kind = seg.get("type", "image")
@@ -895,7 +1015,7 @@ def plan_timeline(tdata, win_start, duration_frames, fps, global_prompt="",
         written_shot_no = {}
         counted = 0
         for shot_i, shot in enumerate(shots):
-            if (shot["prompt"] or "").strip():
+            if shot_has_text(shot):
                 counted += 1
                 written_shot_no[shot_i] = counted
 
@@ -1011,6 +1131,11 @@ def plan_timeline(tdata, win_start, duration_frames, fps, global_prompt="",
     for shot in shots:
         shot["prompt"] = substitute_char_tags(shot["prompt"], char_tag_values)
 
+    # Rendered here, after the tags resolve to their labels and before the shot text is
+    # read back for `(appears in [Shot N])` — a subject that only ever speaks still
+    # appears in the shots where it speaks.
+    speaker_ids = assign_speakers(shots, lambda slot: char_tag_values.get(slot))
+
     if prompt_format == FORMAT_MINIMAX:
         # the guide keeps the soundtrack out of the shot description
         global_prompt, found_audio, found_music = split_audio_music(global_prompt)
@@ -1031,15 +1156,24 @@ def plan_timeline(tdata, win_start, duration_frames, fps, global_prompt="",
         subject_shots = {}
         written_no = 0
         for shot in shots:
-            if not (shot["prompt"] or "").strip():
+            if not shot_has_text(shot):
                 continue
             written_no += 1
+            # dialogue counts: a subject that only ever speaks still appears in that shot
+            body = "%s %s" % (shot["prompt"] or "", shot.get("dialogue_text") or "")
             for entry in ref_labels:
                 num = entry.get("subject")
-                if num and entry["label"] in shot["prompt"]:
+                if num and entry["label"] in body:
                     subject_shots.setdefault(num, []).append(written_no)
 
         retention_lines = build_retention_analysis(ref_labels, subject_shots)
+        # "Do not write (Sx) in retention_analysis" — the IDs belong to vocal events in
+        # detailed_description. Only a hand-written note can put one here, so say so
+        # rather than quietly editing what was typed.
+        if any(SPEAKER_ID_RE.search(line) for line in retention_lines):
+            ref_warnings.append(
+                "A speaker ID (Sx) appears in retention_analysis; the guide reserves those "
+                "for detailed_description.")
 
         # guide 5.3: name the frame anchor inside the shot as well as declaring it above
         for ordinal, texts in pic_texts.items():
@@ -1059,7 +1193,7 @@ def plan_timeline(tdata, win_start, duration_frames, fps, global_prompt="",
         # instruction line. `written` mirrors the shot numbering the body will use.
         instruction = ""
         if not ref_mode_on:
-            written_shots = len([s for s in shots if (s["prompt"] or "").strip()])
+            written_shots = len([s for s in shots if shot_has_text(s)])
             instruction = alignment_instruction(
                 any(e["role"] == ROLE_FIRST for e in events),
                 any(e["role"] == ROLE_LAST for e in events),
@@ -1067,6 +1201,23 @@ def plan_timeline(tdata, win_start, duration_frames, fps, global_prompt="",
         prompt = compile_storyboard_minimax(global_prompt, shots, soundscape, music,
                                             subject_lines, retention_lines, instruction,
                                             summary_line)
+
+        # Length guidance, measured on detailed_description alone — the label blocks and
+        # the sound sections are not what the guide is counting.
+        written_shots = [s for s in shots if shot_has_text(s)]
+        words = len(global_prompt.split()) + sum(
+            len(("%s %s" % (s["prompt"] or "", s.get("dialogue_text") or "")).split())
+            for s in written_shots)
+        if words > DESCRIPTION_MAX_WORDS:
+            ref_warnings.append(
+                "detailed_description is about %d words; the guide suggests %d-%d for "
+                "generation tasks." % (words, DESCRIPTION_MIN_WORDS, DESCRIPTION_MAX_WORDS))
+        elif words and words < DESCRIPTION_MIN_WORDS \
+                and len(written_shots) >= DESCRIPTION_MIN_SHOTS:
+            ref_warnings.append(
+                "detailed_description is about %d words across %d shots; the guide suggests "
+                "%d-%d for generation tasks."
+                % (words, len(written_shots), DESCRIPTION_MIN_WORDS, DESCRIPTION_MAX_WORDS))
     else:
         prompt = compile_storyboard(global_prompt, shots, window_seconds)
         if ref_notes:

--- a/minimax_plan.py
+++ b/minimax_plan.py
@@ -642,6 +642,15 @@ def compile_storyboard_minimax(global_prompt, shots, soundscape="", music="",
         parts.append("overall_soundscape: " + soundscape.strip())
     if (music or "").strip():
         parts.append("non_diegetic_music: " + music.strip())
+    elif parts:
+        # Both guides list non_diegetic_music as a required field, and both write "N/A"
+        # in it — the base guide says to do so "when there is no non-diegetic music",
+        # which is exactly what an empty box means. overall_soundscape deliberately does
+        # not get the same treatment: there "N/A" is reserved for a video the user asked
+        # to be silent, so filling it in would state something nobody said.
+        #
+        # `parts` guards against writing a prompt that is nothing but this line.
+        parts.append("non_diegetic_music: N/A")
 
     return "\n\n".join(parts).strip()
 
@@ -1264,11 +1273,18 @@ def plan_timeline(tdata, win_start, duration_frames, fps, global_prompt="",
             if shot_index is not None and 0 <= shot_index < len(shots):
                 shots[shot_index].setdefault("ref_phrases", []).append(texts["phrase"])
 
-        summary_line = " ".join(x for x in (
-            task_type_prefix(ref_image_slots, ref_video_segs, ref_audio_segs,
-                             tdata.get("task_type_override")) if ref_mode_on else "",
-            (summary or "").strip() or (tdata.get("summary", "") or "").strip(),
-        ) if x)
+        # `summary` is the reference guide's section. The base guide's structure is
+        # explicit and closed — the alignment instruction, then "Three Core Fields
+        # (Required, in this order)" — so on the fl2va path a summary line would be a
+        # section H3 was never trained to read there. The box keeps its text for when the
+        # toolbar goes back.
+        summary_line = ""
+        if ref_mode_on:
+            summary_line = " ".join(x for x in (
+                task_type_prefix(ref_image_slots, ref_video_segs, ref_audio_segs,
+                                 tdata.get("task_type_override")),
+                (summary or "").strip() or (tdata.get("summary", "") or "").strip(),
+            ) if x)
 
         # Only the fl2va path: ref2va has no keyframe slot and its guide asks for no
         # instruction line. `written` mirrors the shot numbering the body will use.
@@ -1294,11 +1310,24 @@ def plan_timeline(tdata, win_start, duration_frames, fps, global_prompt="",
         description_words = len(global_prompt.split()) + sum(
             len(("%s %s" % (s["prompt"] or "", s.get("dialogue_text") or "")).split())
             for s in shots if shot_has_text(s))
-        if description_words > DESCRIPTION_MAX_WORDS:
+        #
+        # Only on the reference path: 350-500 is that guide's figure for its own
+        # detailed_description. The base guide gives no word count at all, so citing one
+        # there would put words in its mouth. The figure is still reported either way.
+        if ref_mode_on and description_words > DESCRIPTION_MAX_WORDS:
             ref_warnings.append(
                 "detailed_description is about %d words; the guide suggests %d-%d for "
                 "generation tasks."
                 % (description_words, DESCRIPTION_MIN_WORDS, DESCRIPTION_MAX_WORDS))
+
+        # Both guides list the three core fields as required, and this is the one that
+        # cannot be filled in for the user: "N/A" here means the video was asked to be
+        # silent, which is a claim only the user can make. H3 generates the audio, so
+        # leaving it out hands the whole soundtrack to the model's guess.
+        if not (soundscape or "").strip():
+            ref_warnings.append(
+                "overall_soundscape is empty; the guide lists it as a required field. "
+                "Describe the ambience, or write N/A if the video is meant to be silent.")
     else:
         prompt = compile_storyboard(global_prompt, shots, window_seconds)
         if ref_notes:

--- a/minimax_plan.py
+++ b/minimax_plan.py
@@ -30,6 +30,13 @@ MAX_REF_FILES = 12          # "at most 12 files in total across all input types"
 REF_VIDEO_MIN_SEC = 2.0     # "each clip must be 2-15 seconds long"
 REF_VIDEO_MAX_SEC = 15.0
 REF_VIDEO_TOTAL_SEC = 15.0  # "total duration <= 15 seconds"
+# Decode bound for a reference video. Its frames are VAE-encoded whole and the resulting
+# latents ride through every sampling step, so this is the biggest lever on memory there
+# is — memory goes with the square of the short edge. 768 x 1344 is the native canvas;
+# the ratio is kept so a lowered cap scales the area with it instead of squaring it away.
+REF_VIDEO_SHORT_EDGE = 768
+REF_VIDEO_ASPECT_BUDGET = 1344 / 768.0
+REF_VIDEO_SIZES = (768, 640, 512, 384, 256)
 # Output envelope: "4-15 seconds" at 24 fps
 TRAINED_MIN_FRAMES = 96
 TRAINED_MAX_FRAMES = 360

--- a/minimax_plan.py
+++ b/minimax_plan.py
@@ -324,6 +324,22 @@ def _subject_sentence(label, description, kind, pictures):
     return "%s is %s shown in %s." % (label, SUBJECT_KINDS[kind], pictures)
 
 
+def _declaration(label, written, generated):
+    """`<Label> is <what the user wrote>.`, or the generated sentence when nothing was.
+
+    The label is prepended rather than expected in the text, so what gets typed is the
+    predicate — "the voice-timbre reference for <Subject 1> (S1)" — and the label can
+    never end up wrong or duplicated. A sentence that already opens with its own label is
+    taken as written, since that is what someone pasting the guide's example will do.
+    """
+    text = (written or "").strip()
+    if not text:
+        return generated
+    if text.startswith(label):
+        return text if text.endswith((".", "!", "?")) else text + "."
+    return "%s is %s." % (label, text.rstrip("."))
+
+
 def build_subject_definitions(subject_slots, ref_image_slots, ref_video_segs,
                               ref_audio_segs):
     """Declare every reference label, and record what each needs in retention_analysis.
@@ -398,9 +414,16 @@ def build_subject_definitions(subject_slots, ref_image_slots, ref_video_segs,
                        "note": s.get("note", ""),
                        "where": texts["where"], "audio": False})
 
+    # A <Video N> or <Audio N> declaration is pure prose — unlike a <Picture N>, it states
+    # no structural fact the planner already knows — so a written one simply replaces it.
+    # That is the only way to reach the guide's own shapes, which name things this node
+    # cannot infer: "<Audio 1> is the voice-timbre reference for <Subject 1> (S1)", or
+    # "<Video 1> is the source video for the target video edit".
     for i, seg in enumerate(ref_video_segs):
         label = "<Video %d>" % (i + 1)
-        lines.append("%s is a reference video: follow its motion and camera work." % label)
+        lines.append(_declaration(
+            label, seg.get("refDesc"),
+            "%s is a reference video: follow its motion and camera work." % label))
         labels.append({"label": label, "kind": "video", "audio": False,
                        "marker": sanitize_retention(seg.get("retention")),
                        "note": (seg.get("refNote") or "").strip(),
@@ -408,13 +431,15 @@ def build_subject_definitions(subject_slots, ref_image_slots, ref_video_segs,
     for i, seg in enumerate(ref_audio_segs):
         label = "<Audio %d>" % (i + 1)
         marker = sanitize_retention(seg.get("retention"), audio=True)
-        # the declaration has to agree with the marker: telling the model to follow a
-        # clip's timbre while retention_analysis says the signal is copied wholesale
-        # describes two different jobs
-        lines.append("%s is a reference audio clip: %s"
-                     % (label, "its signal is reused in the target video."
-                        if marker in ("fully_copy", "partially_copy")
-                        else "follow its voice and timbre."))
+        # the generated declaration has to agree with the marker: telling the model to
+        # follow a clip's timbre while retention_analysis says the signal is copied
+        # wholesale describes two different jobs
+        lines.append(_declaration(
+            label, seg.get("refDesc"),
+            "%s is a reference audio clip: %s"
+            % (label, "its signal is reused in the target video."
+               if marker in ("fully_copy", "partially_copy")
+               else "follow its voice and timbre.")))
         labels.append({"label": label, "kind": "audio", "audio": True, "marker": marker,
                        "note": (seg.get("refNote") or "").strip(), "where": ""})
 

--- a/minimax_plan.py
+++ b/minimax_plan.py
@@ -369,10 +369,15 @@ def build_subject_definitions(subject_slots, ref_image_slots, ref_video_segs,
         subject_no += 1
         label = "<Subject %d>" % subject_no
         s["subject"] = subject_no
-        lines.append(_subject_sentence(label, s.get("note"), s["kind"],
+        # `desc` says what the image defines, `note` says what survives into the target —
+        # two different sentences in two different sections, so they are two fields. One
+        # field would mean a subject-defining image could carry one or the other and never
+        # both, and would have to mean something else again on a frame anchor.
+        lines.append(_subject_sentence(label, s.get("desc"), s["kind"],
                                        "<Picture %d>" % (i + 1)))
         labels.append({"label": label, "marker": s["retention"], "kind": s["kind"],
-                       "note": "", "where": "", "audio": False, "subject": subject_no})
+                       "note": s.get("note", ""), "where": "", "audio": False,
+                       "subject": subject_no})
 
     # --- <Picture N>: only the real frame and storyboard anchors.
     # Character-slot images are deliberately absent — they are cited above instead. So are
@@ -523,9 +528,12 @@ def compile_storyboard_minimax(global_prompt, shots, soundscape="", music="",
 
     Section order is the reference guide's: subject_definitions, summary,
     retention_analysis, detailed_description, then the two sound fields.
-    retention_analysis is the one section written one entry per line, because its entries
-    are `label (where): marker - note` records rather than prose, and running them
-    together makes the markers hard to pick out.
+
+    subject_definitions and retention_analysis are written one entry per line, the way the
+    guide's own example lays them out. Both are lists of records — one per reference label
+    — rather than prose, and running them together into a paragraph makes it genuinely
+    hard to see where one label's definition ends and the next begins. detailed_description
+    stays a single flowing block, because that one really is prose.
     """
     parts = []
 
@@ -535,7 +543,7 @@ def compile_storyboard_minimax(global_prompt, shots, soundscape="", music="",
         parts.append(instruction.strip())
 
     if subject_lines:
-        parts.append("subject_definitions: " + " ".join(subject_lines))
+        parts.append("subject_definitions:\n" + "\n".join(subject_lines))
     if (summary or "").strip():
         parts.append("summary: " + summary.strip())
     if retention_lines:
@@ -610,6 +618,59 @@ def split_audio_music(text):
         if stripped:
             current.append(stripped)
     return "\n".join(kept).strip(), " ".join(sound).strip(), " ".join(music).strip()
+
+
+ANALYSIS_DESC_PREFIX = "description:"
+ANALYSIS_KEEP_PREFIX = "retained:"
+
+
+def split_analysis(text):
+    """Split the Analyze button's two labelled lines into (description, retained).
+
+    The vision model is asked for `DESCRIPTION:` and `RETAINED:`, which fill the slot's
+    two boxes: what the subject *is*, and what has to survive into the target video.
+
+    Local models ignore an output format often enough that the unlabelled case has to be
+    the safe one — everything becomes the description, which is where a single blob of
+    text was going before there was a second box. A label may also arrive lowercased, in
+    bold, or with the model's own preamble above it, so matching is case-insensitive,
+    tolerant of `*` and `#` decoration, and picks up wherever the first label appears.
+
+    Lives here rather than in minimax_media so it can be tested without importing
+    aiohttp or ComfyUI — the same reason split_audio_music is here.
+    """
+    if not text:
+        return "", ""
+    rows = []
+    labelled = False
+    for line in str(text).splitlines():
+        stripped = line.strip().lstrip("*#-• ").strip()
+        low = stripped.lower()
+        if low.startswith(ANALYSIS_DESC_PREFIX):
+            rows.append(("desc", stripped.split(":", 1)[1]))
+            labelled = True
+        elif low.startswith(ANALYSIS_KEEP_PREFIX):
+            rows.append(("keep", stripped.split(":", 1)[1]))
+            labelled = True
+        else:
+            rows.append((None, stripped))
+
+    desc, keep, current = [], [], None
+    for kind, value in rows:
+        if kind:
+            current = desc if kind == "desc" else keep
+        elif current is None:
+            # Before any label. With labels present this is the model's own preamble
+            # ("Sure! Here is the analysis:") and belongs in neither box; with no labels
+            # anywhere it is the whole answer, and the description is where a single blob
+            # of text went before there was a second box.
+            if labelled:
+                continue
+            current = desc
+        value = value.strip().strip("*").strip()
+        if value:
+            current.append(value)
+    return " ".join(desc).strip(), " ".join(keep).strip()
 
 
 def compile_storyboard(global_prompt, shots, total_seconds):
@@ -822,6 +883,7 @@ def plan_timeline(tdata, win_start, duration_frames, fps, global_prompt="",
                     "picture_role": ev["role"],
                     "kind": sanitize_kind(seg.get("refKind")),
                     "retention": sanitize_retention(seg.get("retention")),
+                    "desc": (seg.get("refDesc") or "").strip(),
                     "note": (seg.get("refNote") or "").strip(),
                     "shot_no": written_shot_no.get(ev.get("shot_index")),
                     "at": fmt_seconds(ev["rel_start_f"] / fps)}

--- a/minimax_plan.py
+++ b/minimax_plan.py
@@ -137,26 +137,43 @@ def fmt_seconds(value):
     return "%.1fs" % rounded
 
 
-def substitute_char_tags(text, replacements):
+CHAR_TAG_RE = re.compile(r"@(?:character|char|ref)(\d+)")
+
+
+def substitute_char_tags(text, replacements, later=None, seen=None):
     """Swap @ref1/@character1/@char1 .. @ref9 for their resolved text.
 
     A slot is no longer necessarily a character, so @refN is the name that fits what the
     slots now hold. @characterN/@charN keep working for every slot — prompts written
     against the old three-slot panel must not break.
 
-    Highest slot first: @ref1 is a prefix of @ref10 today only in spirit, but @char1 *is*
-    a prefix of nothing while @ref1 would be of @ref11 if the cap ever moved. Descending
-    order makes that class of bug impossible rather than merely absent.
+    The whole number is read at once, so a slot number that does not exist is left alone
+    rather than half-substituted: @ref11 used to come out as the slot-1 value with a
+    stray "1" welded to it.
+
+    `later` is the base guide's rule for a subject that has no <Subject N> label to lean
+    on. There the identity lives in the prose, so it is written out in full where the
+    subject first appears and named by a short handle afterwards — otherwise "a woman in
+    a red coat" walks into every shot as a different woman. Tags resolve left to right
+    and `seen` carries that across the global block and each shot in turn, so "first"
+    means first in the finished video rather than first in whichever string this is.
     """
     if not text:
         return text or ""
-    for slot in range(MAX_SUBJECT_SLOTS, 0, -1):
+    if seen is None:
+        seen = set()
+
+    def swap(match):
+        slot = int(match.group(1))
         value = replacements.get(slot)
         if not value:
-            continue
-        for tag in ("@character%d" % slot, "@char%d" % slot, "@ref%d" % slot):
-            text = text.replace(tag, value)
-    return text
+            return match.group(0)
+        if later and slot in seen:
+            value = later.get(slot) or value
+        seen.add(slot)
+        return value
+
+    return CHAR_TAG_RE.sub(swap, text)
 
 
 def sanitize_retention(value, audio=False):
@@ -742,23 +759,33 @@ def assign_speakers(shots, label_for_slot):
     """
     ids = {}
     for shot in shots:
-        rendered = []
-        for event in shot.get("dialogue") or []:
-            tag = "<d>[%s] %s</d>" % (event["language"], event["line"])
-            if event["audio"]:
-                rendered.append("<Audio %d> carries %s" % (event["audio"], tag))
-                continue
-            if event["slot"]:
-                who = label_for_slot(event["slot"]) or "an unnamed speaker"
-                key = ("slot", event["slot"])
-            else:
-                who = event["voice"] or "an unnamed speaker"
-                key = ("voice", who.strip().lower())
-            if key not in ids:
-                ids[key] = len(ids) + 1
-            rendered.append("%s (S%d) %s, %s" % (who, ids[key], event["delivery"], tag))
-        shot["dialogue_text"] = " ".join(rendered)
+        render_speakers(shot, ids, label_for_slot)
     return ids
+
+
+def render_speakers(shot, ids, label_for_slot):
+    """One shot's vocal events, numbering any speaker met here for the first time.
+
+    Split out of assign_speakers so a caller can interleave it with the prose
+    substitution, shot by shot: which mention of a subject is its *first* depends on the
+    prose and the dialogue together, not on either one read to the end on its own.
+    """
+    rendered = []
+    for event in shot.get("dialogue") or []:
+        tag = "<d>[%s] %s</d>" % (event["language"], event["line"])
+        if event["audio"]:
+            rendered.append("<Audio %d> carries %s" % (event["audio"], tag))
+            continue
+        if event["slot"]:
+            who = label_for_slot(event["slot"]) or "an unnamed speaker"
+            key = ("slot", event["slot"])
+        else:
+            who = event["voice"] or "an unnamed speaker"
+            key = ("voice", who.strip().lower())
+        if key not in ids:
+            ids[key] = len(ids) + 1
+        rendered.append("%s (S%d) %s, %s" % (who, ids[key], event["delivery"], tag))
+    shot["dialogue_text"] = " ".join(rendered)
 
 
 ANALYSIS_DESC_PREFIX = "description:"
@@ -920,6 +947,10 @@ def plan_timeline(tdata, win_start, duration_frames, fps, global_prompt="",
         subject_slots.append({
             "images": images_list,
             "description": info.get("description", "") or "",
+            # what to call the subject after its first appearance, when there is no
+            # <Subject N> label to name it with. Empty repeats the description, which is
+            # what every timeline written before this field did.
+            "short_name": (info.get("shortName", "") or "").strip(),
             "kind": sanitize_kind(info.get("kind")),
             "retention": sanitize_retention(info.get("retention")),
             "note": info.get("retentionNote", "") or "",
@@ -971,6 +1002,7 @@ def plan_timeline(tdata, win_start, duration_frames, fps, global_prompt="",
 
     # --- reference ordinals, in the order the tokenizer will present them ---
     char_tag_values = {}
+    char_tag_later = {}      # what a tag resolves to after its first appearance
     ref_notes = []
     ref_image_slots = []     # {"source": "char"/"input"/"timeline", ...} in <Picture i> order
 
@@ -1042,9 +1074,15 @@ def plan_timeline(tdata, win_start, duration_frames, fps, global_prompt="",
                 slot["keyframe"] = ev["role"]
             ref_image_slots.append(slot)
     else:
+        # The base guide has no subject_definitions section: with references off, a subject
+        # exists only as prose inside integrated_multimodal_description, established "when
+        # a speaker first appears" and referred to consistently after that. So the slot's
+        # description *is* the definition, dropped in where the tag sits.
         for slot_idx, slot in enumerate(subject_slots):
             if slot["description"]:
                 char_tag_values[slot_idx + 1] = slot["description"]
+                if slot["short_name"]:
+                    char_tag_later[slot_idx + 1] = slot["short_name"]
 
     # --- reference video / audio tracks ---
     ref_video_segs, ref_audio_segs = [], []
@@ -1065,6 +1103,17 @@ def plan_timeline(tdata, win_start, duration_frames, fps, global_prompt="",
     # The per-type caps are not the whole story: H3 also takes at most 12 reference files
     # across all types. Trim from the back so the earlier, more deliberate references win.
     ref_warnings = []
+
+    # The panel keeps its images either way, so switching the toolbar back does not cost
+    # the work — but on this path they are never sent, and a slot that looks filled and
+    # does nothing is worth one line.
+    if not ref_mode_on:
+        unsent = sum(1 for s in subject_slots if s["images"])
+        if unsent:
+            ref_warnings.append(
+                "%d subject slot(s) hold reference images; fl2va sends none of them. Only "
+                "the written description reaches the prompt." % unsent)
+
     total_files = len(ref_image_slots) + len(ref_video_segs) + len(ref_audio_segs)
     if total_files > MAX_REF_FILES:
         excess = total_files - MAX_REF_FILES
@@ -1119,28 +1168,50 @@ def plan_timeline(tdata, win_start, duration_frames, fps, global_prompt="",
         # A slot whose pictures were all trimmed away must not keep pointing at an ordinal
         # that no longer exists; it falls back to its description, exactly as it would
         # with references off.
-        char_tag_values = {}
+        char_tag_values, char_tag_later = {}, {}
         for slot_index, slot in enumerate(subject_slots):
             ordinals = [i + 1 for i, s in enumerate(ref_image_slots)
                         if s.get("source") == "char" and s.get("slot") == slot_index]
             if ordinals:
                 char_tag_values[slot_index + 1] = "<Picture %d>" % ordinals[0]
             elif slot["description"]:
+                # no picture, so no label — this slot is prose here too, and takes the
+                # base guide's first-in-full-then-a-handle treatment with it
                 char_tag_values[slot_index + 1] = slot["description"]
+                if slot["short_name"]:
+                    char_tag_later[slot_index + 1] = slot["short_name"]
 
         if prompt_format == FORMAT_MINIMAX:
             # a named subject beats a bare picture label: it survives across cuts
             for slot, subject in subject_of_slot.items():
                 char_tag_values[slot] = "<Subject %d>" % subject
 
-    global_prompt = substitute_char_tags(global_prompt, char_tag_values)
-    for shot in shots:
-        shot["prompt"] = substitute_char_tags(shot["prompt"], char_tag_values)
+    # Left to right through the finished video — the global block, then each shot in turn,
+    # its prose before its dialogue. `seen_slots` is what makes "the first appearance"
+    # mean the first one anywhere rather than the first one in this particular string:
+    # a subject that speaks in shot 1 and is described in shot 2 is introduced by its
+    # spoken line, not re-introduced afterwards.
+    #
+    # Speakers are numbered in the same pass, which also has to happen after the tags
+    # resolve to their labels and before the shot text is read back for
+    # `(appears in [Shot N])` — a subject that only ever speaks still appears in the
+    # shots where it speaks.
+    seen_slots = set()
+    global_prompt = substitute_char_tags(global_prompt, char_tag_values, char_tag_later,
+                                         seen_slots)
 
-    # Rendered here, after the tags resolve to their labels and before the shot text is
-    # read back for `(appears in [Shot N])` — a subject that only ever speaks still
-    # appears in the shots where it speaks.
-    speaker_ids = assign_speakers(shots, lambda slot: char_tag_values.get(slot))
+    def label_for_slot(slot):
+        value = char_tag_values.get(slot)
+        if slot in seen_slots:
+            value = char_tag_later.get(slot) or value
+        seen_slots.add(slot)
+        return value
+
+    speaker_ids = {}
+    for shot in shots:
+        shot["prompt"] = substitute_char_tags(shot["prompt"], char_tag_values,
+                                              char_tag_later, seen_slots)
+        render_speakers(shot, speaker_ids, label_for_slot)
 
     # only the minimax format has a detailed_description to measure; the key exists either
     # way so every caller can read it without checking the format first

--- a/minimax_plan.py
+++ b/minimax_plan.py
@@ -681,12 +681,11 @@ DIALOGUE_DEFAULT_DELIVERY = "says"
 
 SPEAKER_ID_RE = re.compile(r"\(S\d+\)")
 
-# "Generation tasks typically span 350-500 words". The floor is only worth mentioning once
-# a timeline is a real storyboard — firing it on a two-shot test would be noise, and the
-# guide itself warns against "mechanical word-count adherence".
+# "Generation tasks typically span 350-500 words", which the preview reports as a figure so
+# the range is visible without being nagged about. The guide itself warns against
+# "mechanical word-count adherence".
 DESCRIPTION_MIN_WORDS = 350
 DESCRIPTION_MAX_WORDS = 500
-DESCRIPTION_MIN_SHOTS = 3
 
 
 def split_dialogue(text):
@@ -1136,6 +1135,10 @@ def plan_timeline(tdata, win_start, duration_frames, fps, global_prompt="",
     # appears in the shots where it speaks.
     speaker_ids = assign_speakers(shots, lambda slot: char_tag_values.get(slot))
 
+    # only the minimax format has a detailed_description to measure; the key exists either
+    # way so every caller can read it without checking the format first
+    description_words = 0
+
     if prompt_format == FORMAT_MINIMAX:
         # the guide keeps the soundtrack out of the shot description
         global_prompt, found_audio, found_music = split_audio_music(global_prompt)
@@ -1202,22 +1205,22 @@ def plan_timeline(tdata, win_start, duration_frames, fps, global_prompt="",
                                             subject_lines, retention_lines, instruction,
                                             summary_line)
 
-        # Length guidance, measured on detailed_description alone — the label blocks and
-        # the sound sections are not what the guide is counting.
-        written_shots = [s for s in shots if shot_has_text(s)]
-        words = len(global_prompt.split()) + sum(
+        # Measured on detailed_description alone — the label blocks and the sound sections
+        # are not what the guide is counting.
+        #
+        # Reported as a figure, not a warning. The guide's 350-500 is a lot of words for a
+        # 5-15 second clip, so being under it is the ordinary state here rather than a
+        # fault: warning about it fired on essentially every timeline, which is how a
+        # warning area stops being read at all. Only overshooting the range is called out,
+        # where the prompt really has outgrown what the guide describes.
+        description_words = len(global_prompt.split()) + sum(
             len(("%s %s" % (s["prompt"] or "", s.get("dialogue_text") or "")).split())
-            for s in written_shots)
-        if words > DESCRIPTION_MAX_WORDS:
+            for s in shots if shot_has_text(s))
+        if description_words > DESCRIPTION_MAX_WORDS:
             ref_warnings.append(
                 "detailed_description is about %d words; the guide suggests %d-%d for "
-                "generation tasks." % (words, DESCRIPTION_MIN_WORDS, DESCRIPTION_MAX_WORDS))
-        elif words and words < DESCRIPTION_MIN_WORDS \
-                and len(written_shots) >= DESCRIPTION_MIN_SHOTS:
-            ref_warnings.append(
-                "detailed_description is about %d words across %d shots; the guide suggests "
-                "%d-%d for generation tasks."
-                % (words, len(written_shots), DESCRIPTION_MIN_WORDS, DESCRIPTION_MAX_WORDS))
+                "generation tasks."
+                % (description_words, DESCRIPTION_MIN_WORDS, DESCRIPTION_MAX_WORDS))
     else:
         prompt = compile_storyboard(global_prompt, shots, window_seconds)
         if ref_notes:
@@ -1241,6 +1244,7 @@ def plan_timeline(tdata, win_start, duration_frames, fps, global_prompt="",
         "ref_image_slots": ref_image_slots, "ref_notes": ref_notes,
         "ref_video_segs": ref_video_segs, "ref_audio_segs": ref_audio_segs,
         "ref_warnings": ref_warnings, "prompt_format": prompt_format,
+        "description_words": description_words,
         "char_tag_values": char_tag_values,
         "win_start": win_start, "duration_frames": duration_frames, "fps": fps,
         "window_seconds": window_seconds,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "minimaxh3-director"
 description = "A timeline editor for MiniMax H3 — storyboard prompts, first/last keyframes, image/video/audio references, native joint audio, live sampling preview, retakes and shot chaining."
-version = "0.1.5"
+version = "0.2.0"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"
 # Nothing beyond what ComfyUI itself already installs.

--- a/test_plan.py
+++ b/test_plan.py
@@ -224,6 +224,103 @@ tags = compile(tl([img(0, 144, "a.png", prompt="@ref9 and @char1 meet")],
 check_in("@ref9 reaches the ninth slot", "<Subject 9> and <Subject 1> meet", tags["prompt"])
 check_not_in("no raw @ref tag survives", "@ref", tags["prompt"])
 
+check_in("a slot number that does not exist is left alone",
+         "@ref11", compile(tl([img(0, 144, "a.png", prompt="@ref11 waits")],
+                              ref_mode="ON", characters=chars))["prompt"])
+
+# ------------------------------------------------- subjects with references off
+# references/base-en.txt has no subject_definitions section at all: with refs off a
+# subject exists only as prose inside integrated_multimodal_description, established
+# "when a speaker first appears" and referred to consistently after that. So the slot's
+# description is written out in full at the first mention and abbreviated afterwards —
+# otherwise "a middle-aged baker" walks into every shot as a different baker.
+BAKER = "a middle-aged baker with a calm, slightly raspy voice"
+
+
+def base_tl(shots, short_name="the baker", **extra):
+    d = {"reference_mode": "OFF", "prompt_format": "minimax",
+         "global_prompt": "Live-action, cinematic, a small street bakery before sunrise.",
+         "subjects": [{"description": BAKER, "shortName": short_name}],
+         "segments": [{"type": "text", "start": i * 120, "length": 120, "prompt": t}
+                      for i, t in enumerate(shots)]}
+    d.update(extra)
+    return d
+
+
+handled = compile(base_tl(["@ref1 places a fresh loaf on the counter.\n"
+                           "@ref1 says: First batch of the morning.",
+                           "the camera cuts to a close-up as @ref1 wipes the counter."]),
+                  duration_f=240)["prompt"]
+check_in("the first mention is written out in full", "[Shot 1] %s places" % BAKER, handled)
+check_in("a later mention in the same shot uses the handle",
+         "the baker (S1) says, <d>[English] First batch of the morning.</d>", handled)
+check_in("a later shot uses the handle too", "as the baker wipes the counter", handled)
+check("the description is written exactly once", handled.count(BAKER), 1)
+
+# An empty handle is what every timeline written before the field carried, so it has to
+# keep meaning what it meant then: repeat the description at every mention.
+repeated = compile(base_tl(["@ref1 places a fresh loaf on the counter.",
+                            "@ref1 wipes the counter."], short_name=""),
+                   duration_f=240)["prompt"]
+check("no handle repeats the description", repeated.count(BAKER), 2)
+
+# "First" is a property of the finished video, not of whichever string is being scanned:
+# a subject whose first appearance is a spoken line is introduced by that line.
+speaks_first = compile(base_tl(["@ref1 says: First batch of the morning.",
+                                "@ref1 wipes the counter."]), duration_f=240)["prompt"]
+check_in("a subject introduced by its own dialogue is named in full there",
+         "%s (S1) says," % BAKER, speaks_first)
+check_in("and abbreviated in the prose that follows", "the baker wipes", speaks_first)
+
+# Same rule with references on, for a slot with no picture behind it: there is no
+# <Subject N> label to lean on there either, so the prose has to carry the identity.
+noref = compile({"reference_mode": "ON", "prompt_format": "minimax", "global_prompt": "",
+                 "subjects": [{"description": BAKER, "shortName": "the baker"}],
+                 "segments": [{"type": "text", "start": 0, "length": 120,
+                               "prompt": "@ref1 opens the shutters."},
+                              {"type": "text", "start": 120, "length": 120,
+                               "prompt": "@ref1 slices the loaf."}]},
+                duration_f=240)["prompt"]
+check("an unpictured subject is still established once", noref.count(BAKER), 1)
+check_in("and abbreviated after that", "the baker slices the loaf", noref)
+
+# A slot that *does* have a picture already has a stable handle — <Subject 1> — so the
+# field is ignored rather than competing with it.
+pictured = compile(tl([img(0, 144, "a.png", prompt="@ref1 opens the shutters"),
+                       img(144, 144, "b.png", prompt="@ref1 slices the loaf")],
+                      ref_mode="ON",
+                      subjects=[{"images": [{"b64": "x", "name": "c.png"}],
+                                 "description": BAKER, "shortName": "the baker"}]))["prompt"]
+check_in("a pictured subject keeps its label at the first mention",
+         "<Subject 1> opens the shutters", pictured)
+check_in("and at every mention after it", "<Subject 1> slices the loaf", pictured)
+check_not_in("the handle does not leak into the ref2va path", "the baker", pictured)
+
+check_in("subject images are called out as unsent on the fl2va path",
+         "fl2va sends none of them",
+         " ".join(compile(tl([img(0, 144)], characters=chars))["ref_warnings"]))
+
+# The whole base-guide prompt: no subject_definitions, no retention_analysis, the section
+# name the base guide uses rather than the reference guide's, and the identity carried by
+# the prose alone.
+BASE_GOLDEN = (
+    "integrated_multimodal_description: Live-action, cinematic, a small street bakery "
+    "before sunrise. "
+    "[Shot 1] %s places a fresh loaf on the counter. "
+    "the baker (S1) says, <d>[English] First batch of the morning.</d> "
+    "[Shot 2] At 00:05.000, the camera cuts to a close-up as the baker wipes the counter."
+    "\n\n"
+    "overall_soundscape: Wooden shutters scrape open over a quiet street."
+    "\n\n"
+    "non_diegetic_music: N/A" % BAKER)
+check("the whole refs-off prompt matches the base guide",
+      compile(base_tl(["@ref1 places a fresh loaf on the counter.\n"
+                       "@ref1 says: First batch of the morning.",
+                       "the camera cuts to a close-up as @ref1 wipes the counter."],
+                      overall_soundscape="Wooden shutters scrape open over a quiet street.",
+                      non_diegetic_music="N/A"),
+              duration_f=240)["prompt"], BASE_GOLDEN)
+
 # ------------------------------------------------- full-reference: the whole prompt
 # The one check that pins the *entire* output against references/ref-en.txt: section set
 # and order (subject_definitions, summary, retention_analysis, detailed_description, then

--- a/test_plan.py
+++ b/test_plan.py
@@ -512,16 +512,30 @@ check_in("a speaker ID in a retention note is reported",
                           )["ref_warnings"]))
 check("a clean timeline reports no speaker-ID warning",
       any("(Sx)" in w for w in talk["ref_warnings"]), False)
+# The word count is a figure in the preview badge, not a warning. The guide's 350-500 is a
+# lot for a 5-15s clip, so being under it is the ordinary state here — warning about it
+# fired on essentially every timeline, which is how a warnings area stops being read.
 long_shots = [img(i * 20, 20, "%d.png" % i, prompt=" ".join(["word"] * 200))
               for i in range(3)]
-check_in("an over-long description is reported",
+check_in("only overshooting the range is warned about",
          "the guide suggests 350-500",
          " ".join(compile(tl(long_shots, ref_mode="ON"), duration_f=240)["ref_warnings"]))
-check("a two-shot test is not nagged for being short",
-      any("guide suggests" in w for w in
-          compile(tl([img(0, 120, "a.png", prompt="she enters"),
-                      img(120, 120, "b.png", prompt="she leaves")], ref_mode="ON"),
-                  duration_f=240)["ref_warnings"]), False)
+ordinary = compile(tl([img(i * 96, 96, "%d.png" % i, prompt="she walks past the stalls")
+                       for i in range(3)], ref_mode="ON"), duration_f=288)
+check("an ordinary short timeline is not nagged",
+      any("guide suggests" in w for w in ordinary["ref_warnings"]), False)
+check("...but its word count is still reported", ordinary["description_words"], 21)
+check("the count covers the global prompt, shot text and dialogue",
+      compile(tl([img(0, 240, "a.png", prompt="she waits\n@ref1 says: hello there")],
+                 ref_mode="ON", global_prompt="one two three",
+                 subjects=[{"images": [{"b64": "x", "name": "c.png"}],
+                            "description": "a woman"}]),
+              duration_f=240)["description_words"],
+      # "one two three" + "she waits" + "<Subject 1> (S1) says, <d>[English] hello there</d>"
+      3 + 2 + 7)
+check("the comfyui format reports no count rather than failing",
+      compile(tl([img(0, 240, "a.png", prompt="she waits")], ref_mode="ON",
+                 prompt_format="comfyui"), duration_f=240)["description_words"], 0)
 
 # ------------------------------------------------- Analyze output parsing
 check("split_analysis reads both labelled lines",

--- a/test_plan.py
+++ b/test_plan.py
@@ -1066,6 +1066,17 @@ check("a subject of 0 or nonsense is treated as unassigned",
        plan._audio_subject_slot({"subject": "none"}), plan._audio_subject_slot({}),
        plan._audio_subject_slot({"subject": "2"})),
       (None, None, None, None, 2))
+# The editor's "Voice of" menu labels itself from this, so it must be the planner's own
+# numbering and not the slot numbers: an empty slot 1 makes the image in slot 2 <Subject 1>.
+gap = compile(tl([img(0, 288, "a.png", prompt="he waits")], ref_mode="ON",
+                 characters=[{"images": [], "description": ""},
+                             {"images": [{"b64": "x", "name": "c.png"}],
+                              "description": "a man"}]))
+check("the slot -> subject map skips slots that hand over no image",
+      gap["subject_of_slot"], {2: 1})
+check("and it is empty with references off",
+      compile(tl([img(0, 288, "a.png", prompt="x")], characters=two_chars))["subject_of_slot"],
+      {})
 check("a clip pointing at a slot with no images binds nothing",
       "voice-timbre reference" in
       compile(tl([img(0, 288, "a.png", prompt="x")], ref_mode="ON",

--- a/test_plan.py
+++ b/test_plan.py
@@ -1,6 +1,7 @@
 """Offline checks for minimax_plan.py — the whole planner, no server, no pixels.
 
-`minimax_plan` imports nothing but json and logging on purpose, so this runs anywhere:
+`minimax_plan` imports nothing outside the standard library on purpose, so this runs
+anywhere:
 
     python test_plan.py
 
@@ -12,6 +13,7 @@ Run it after any change to minimax_plan.py, before committing.
 """
 import importlib.util
 import os
+import re
 import sys
 
 HERE = os.path.dirname(os.path.abspath(__file__))
@@ -425,6 +427,101 @@ check("a sentence pasted with its own label is taken as written",
       "<Audio 1> is the synchronized track of <Video 1>.")
 check("nothing written falls back to the generated sentence",
       plan._declaration("<Audio 1>", "   ", "generated"), "generated")
+
+# ------------------------------------------------- speakers and dialogue
+# Guide 5.1 and 5.4: speakers carry stable (Sx) IDs assigned by the order of actual vocal
+# events in the target video, reused at every later event; dialogue sits inside
+# <d>[Language] ...</d>; and a cue inside reused audio names <Audio N> with no invented ID.
+prose, spoken = plan.split_dialogue(
+    "she jerks her hand back\n@ref1 exclaims with light annoyance: Hey! Watch your dog!")
+check("dialogue is lifted out of the prose", prose, "she jerks her hand back")
+check("the tag, delivery and line are read apart",
+      (spoken[0]["slot"], spoken[0]["delivery"], spoken[0]["line"]),
+      (1, "exclaims with light annoyance", "Hey! Watch your dog!"))
+check("English is the default language", spoken[0]["language"], "English")
+check("a bare tag still speaks",
+      plan.split_dialogue("@ref2: Hello")[1][0]["delivery"], plan.DIALOGUE_DEFAULT_DELIVERY)
+check("a language can be named",
+      [(e["language"], e["line"]) for e in
+       plan.split_dialogue("@ref1 [French] murmure: Bonjour")[1]],
+      [("French", "Bonjour")])
+check("a tag mid-line is prose, not dialogue",
+      plan.split_dialogue("she looks at @ref1: a long pause")[1], [])
+check("an unnamed voice carries its own description",
+      plan.split_dialogue("@voice(a low male narrator) says: In the beginning")[1][0]["voice"],
+      "a low male narrator")
+
+talk = compile(tl([img(0, 72, "a.png", prompt="@ref1 holds a cookie\n"
+                                              "@ref1 exclaims with annoyance: Watch your dog!"),
+                   img(72, 48, "b.png", prompt="@ref2 says with a playful tone: He likes cookies."),
+                   img(120, 120, "c.png", prompt="@ref1 replies: He has good taste.")],
+                  ref_mode="ON",
+                  subjects=[{"images": [{"b64": "x", "name": "w.png"}],
+                             "description": "a young blonde woman"},
+                            {"images": [{"b64": "y", "name": "m.png"}],
+                             "description": "a young man in a hoodie"}]),
+               duration_f=240)
+check_in("a speaking subject keeps its label and gains a speaker ID",
+         "<Subject 1> (S1) exclaims with annoyance, <d>[English] Watch your dog!</d>",
+         talk["prompt"])
+check_in("the second speaker is S2", "<Subject 2> (S2) says with a playful tone,",
+         talk["prompt"])
+check_in("the first speaker keeps S1 when they speak again",
+         "<Subject 1> (S1) replies, <d>[English] He has good taste.</d>", talk["prompt"])
+check("exactly two speakers were numbered",
+      len(set(re.findall(r"\(S\d+\)", talk["prompt"]))), 2)
+check_not_in("no speaker ID leaks into retention_analysis",
+             "(S", talk["prompt"].split("retention_analysis:")[1].split("detailed_description")[0])
+check_in("a subject that speaks counts as appearing in that shot",
+         "<Subject 2> (appears in [Shot 2]):", talk["prompt"])
+
+# a shot whose only content is a spoken line is still a shot
+only_talk = compile(tl([img(0, 120, "a.png", prompt="she waits"),
+                        {"type": "text", "start": 120, "length": 120,
+                         "prompt": "@ref1 whispers: at last"}],
+                       ref_mode="ON",
+                       subjects=[{"images": [{"b64": "x", "name": "w.png"}],
+                                  "description": "a woman"}]),
+                    duration_f=240)
+check_in("a dialogue-only shot is still numbered and kept",
+         "[Shot 2] At 00:05.000, <Subject 1> (S1) whispers, <d>[English] at last</d>",
+         only_talk["prompt"])
+
+# guide 5.4: verbal content inside reused audio has no independent vocal source
+bgm = compile(tl([img(0, 240, "a.png", prompt="@audio1: we'll meet again")], ref_mode="ON",
+                 audioSegments=[{"audioFile": "song.wav", "start": 0, "length": 240,
+                                 "retention": "fully_copy"}]),
+              duration_f=240, use_custom_audio=True)
+check_in("a line carried by reused audio names its source",
+         "<Audio 1> carries <d>[English] we'll meet again</d>", bgm["prompt"])
+check_not_in("...and invents no speaker ID for it", "(S1)", bgm["prompt"])
+
+# the comfyui format has no <d> notation, but must not silently drop the line either
+cf_talk = compile(tl([img(0, 240, "a.png", prompt="@ref1 says: hello")], ref_mode="ON",
+                     prompt_format="comfyui",
+                     subjects=[{"images": [{"b64": "x", "name": "w.png"}],
+                                "description": "a woman"}]), duration_f=240)
+check_in("dialogue survives into the comfyui format", "hello", cf_talk["prompt"])
+
+# ------------------------------------------------- spec warnings
+check_in("a speaker ID in a retention note is reported",
+         "reserves those for detailed_description",
+         " ".join(compile(tl([], ref_mode="ON",
+                             subjects=[{"images": [{"b64": "x", "name": "c.png"}],
+                                        "retentionNote": "her voice (S1) is kept"}])
+                          )["ref_warnings"]))
+check("a clean timeline reports no speaker-ID warning",
+      any("(Sx)" in w for w in talk["ref_warnings"]), False)
+long_shots = [img(i * 20, 20, "%d.png" % i, prompt=" ".join(["word"] * 200))
+              for i in range(3)]
+check_in("an over-long description is reported",
+         "the guide suggests 350-500",
+         " ".join(compile(tl(long_shots, ref_mode="ON"), duration_f=240)["ref_warnings"]))
+check("a two-shot test is not nagged for being short",
+      any("guide suggests" in w for w in
+          compile(tl([img(0, 120, "a.png", prompt="she enters"),
+                      img(120, 120, "b.png", prompt="she leaves")], ref_mode="ON"),
+                  duration_f=240)["ref_warnings"]), False)
 
 # ------------------------------------------------- Analyze output parsing
 check("split_analysis reads both labelled lines",

--- a/test_plan.py
+++ b/test_plan.py
@@ -836,6 +836,41 @@ check_in("a written summary follows the prefix",
          compile(tl([img(0, 288, "a.png", prompt="she waits")], ref_mode="ON",
                     summary="She crosses the market."))["prompt"])
 
+# `summary` is a box like any other: a tag typed in it reached the model as a literal
+# "@ref1" before, because only the global prompt and the shot prompts were substituted.
+tagged_summary = compile(tl([img(0, 288, "a.png", prompt="@ref1 waits")], ref_mode="ON",
+                            subjects=[{"images": [{"b64": "x", "name": "c.png"}],
+                                       "description": "a woman in a red coat"}],
+                            summary="@ref1 crosses the market."))
+check_in("a tag in the summary resolves like every other box",
+         "summary: [keyframe completion + reference generation] <Subject 1> crosses the "
+         "market.", tagged_summary["prompt"])
+check_not_in("no raw tag survives into the prompt", "@ref1", tagged_summary["prompt"])
+
+# The guide's section order puts summary above detailed_description, so that is where a
+# subject with no picture to lean on is introduced in full — and the shots below it get
+# the short handle, not a second introduction.
+noimg = compile(tl([img(0, 288, "a.png", prompt="@ref1 waits")], ref_mode="ON",
+                   subjects=[{"description": "a middle-aged baker with a raspy voice",
+                              "shortName": "the baker"}],
+                   summary="@ref1 opens the shop."))
+check_in("an imageless subject is introduced in the summary, being first in reading order",
+         "summary: [keyframe completion] a middle-aged baker with a raspy voice opens the "
+         "shop.", noimg["prompt"])
+check_in("and the shot below it uses the short name",
+         "[Shot 1] the baker waits.", noimg["prompt"])
+
+# fl2va has no summary section, so substituting one would mark a subject as introduced on
+# the strength of a sentence that never gets written out.
+noimg_off = compile(tl([img(0, 288, "a.png", prompt="@ref1 waits")],
+                       subjects=[{"description": "a middle-aged baker with a raspy voice",
+                                  "shortName": "the baker"}],
+                       summary="@ref1 opens the shop."))
+check_not_in("the hidden summary does not introduce anyone on the fl2va path",
+             "the baker waits", noimg_off["prompt"])
+check_in("so the shot still carries the full description",
+         "a middle-aged baker with a raspy voice waits", noimg_off["prompt"])
+
 # ------------------------------------------------- the cap leaves nothing dangling
 # The 12-file cap trims from the back. Every declaration and retention line has to
 # describe a reference that survived, and nothing may reference a dropped ordinal.

--- a/test_plan.py
+++ b/test_plan.py
@@ -245,12 +245,12 @@ spec_tl = {
     "overall_soundscape": "Soft indoor coffee-shop room tone throughout.",
     "non_diegetic_music": "N/A"}
 SPEC_GOLDEN = (
-    "subject_definitions: "
+    "subject_definitions:\n"
     "<Subject 1> is the coffee shop with an exposed brick wall and an orange tufted sofa, "
-    "shown in <Picture 1>. "
-    "<Subject 2> is a fluffy white Samoyed with a curved tail, shown in <Picture 2>. "
-    "<Picture 3> is the first frame of [Shot 1]. "
-    "<Picture 4> is the last frame of [Shot 2]. "
+    "shown in <Picture 1>.\n"
+    "<Subject 2> is a fluffy white Samoyed with a curved tail, shown in <Picture 2>.\n"
+    "<Picture 3> is the first frame of [Shot 1].\n"
+    "<Picture 4> is the last frame of [Shot 2].\n"
     "<Audio 1> is a reference audio clip: its signal is reused in the target video."
     "\n\n"
     "summary: [keyframe completion + reference generation + audio reuse]"
@@ -342,6 +342,80 @@ noted = compile(tl([img(0, 144)], ref_mode="ON",
 check_in("a written retention note wins over the generated one",
          "attribute_transfer - her coat colour moves to the stallholder.", noted["prompt"])
 
+# ------------------------------------------------- written retention notes
+# The guide's own retention lines name the subject's actual features rather than a stock
+# phrase — "the Samoyed's thick white fur, pointed ears, dark nose, and curved tail are
+# retained". Every reference type has to be able to say that.
+noted_pic = compile(tl([img(0, 144, "a.png", prompt="she enters",
+                            refNote="the doorway framing and the rain on the glass")],
+                       ref_mode="ON"))
+check_in("a written note replaces a picture's generated sentence",
+         "<Picture 1> ([Shot 1] first frame): fully_preserved - the doorway framing and "
+         "the rain on the glass.", noted_pic["prompt"])
+
+noted_vid = compile(tl([], ref_mode="ON",
+                       motionSegments=[{"videoFile": "v.mp4", "fileName": "v.mp4",
+                                        "start": 0, "length": 120,
+                                        "retention": "partially_preserved",
+                                        "refNote": "the slow push-in is kept, the handheld "
+                                                   "drift is not"}]))
+check_in("a written note replaces a reference video's generated sentence",
+         "<Video 1> (motion and camera work): partially_preserved - the slow push-in is "
+         "kept, the handheld drift is not.", noted_vid["prompt"])
+
+noted_aud = compile(tl([], ref_mode="ON",
+                       audioSegments=[{"audioFile": "a.wav", "start": 0, "length": 96,
+                                       "retention": "reference",
+                                       "refNote": "the speaker's measured delivery guides "
+                                                  "the dialogue"}]),
+                    use_custom_audio=True)
+check_in("a written note replaces an audio clip's generated sentence",
+         "<Audio 1>: reference - the speaker's measured delivery guides the dialogue.",
+         noted_aud["prompt"])
+check("a note already ending in punctuation gains none",
+      compile(tl([], ref_mode="ON",
+                 subjects=[{"images": [{"b64": "x", "name": "c.png"}],
+                            "retentionNote": "Her scar stays on the left cheek!"}])
+              )["prompt"].count("cheek!"), 1)
+
+# the exact line the reference guide prints, reproduced end to end
+samoyed = compile(tl([img(0, 120, "a.png", prompt="@ref1 lunges for the cookie"),
+                      img(120, 120, "b.png", prompt="@ref1 is pulled back")],
+                     ref_mode="ON",
+                     subjects=[{"images": [{"b64": "x", "name": "dog.png"}],
+                                "kind": "animal",
+                                "description": "the fluffy white Samoyed",
+                                "retention": "fully_preserved",
+                                "retentionNote": "the Samoyed's thick white fur, pointed "
+                                                 "ears, dark nose, and curved tail are "
+                                                 "retained"}]),
+                   duration_f=240)
+check_in("the guide's own retention line can be reproduced exactly",
+         "<Subject 1> (appears in [Shot 1], [Shot 2]): fully_preserved - the Samoyed's "
+         "thick white fur, pointed ears, dark nose, and curved tail are retained.",
+         samoyed["prompt"])
+
+# ------------------------------------------------- Analyze output parsing
+check("split_analysis reads both labelled lines",
+      plan.split_analysis("DESCRIPTION: A fluffy white Samoyed.\n"
+                          "RETAINED: thick white fur, pointed ears"),
+      ("A fluffy white Samoyed.", "thick white fur, pointed ears"))
+check("unlabelled output is all description — where a single blob went before",
+      plan.split_analysis("A fluffy white Samoyed with a curved tail."),
+      ("A fluffy white Samoyed with a curved tail.", ""))
+check("markdown decoration around the labels is tolerated",
+      plan.split_analysis("**Description:** A night market.\n**Retained:** neon signage"),
+      ("A night market.", "neon signage"))
+check("a chatty preamble is dropped once a label appears",
+      plan.split_analysis("Sure! Here is the analysis:\nDESCRIPTION: A red coat.\n"
+                          "RETAINED: the collar shape"),
+      ("A red coat.", "the collar shape"))
+check("only one label is fine", plan.split_analysis("DESCRIPTION: just this"),
+      ("just this", ""))
+check("a multi-line section is joined",
+      plan.split_analysis("RETAINED: the fur\nand the tail")[1], "the fur and the tail")
+check("split_analysis on empty text", plan.split_analysis(""), ("", ""))
+
 # ------------------------------------------------- subject kinds
 # <Subject N> is not a character slot: "people, animals, or objects; scenes, backgrounds,
 # or environments; clothing, props, interfaces, or visual effects; styles, actions,
@@ -382,12 +456,18 @@ check_in("a storyboard image retains planning, not framing",
 
 subj_role = compile(tl([img(0, 144, "a.png", prompt="she enters"),
                         img(144, 144, "coat.png", prompt="a wide shot", refRole="subject",
-                            refKind="clothing", refNote="a long red wool coat")],
+                            refKind="clothing", refDesc="a long red wool coat",
+                            refNote="the cut and the brass buttons are kept")],
                        ref_mode="ON"))
 check_in("a subject-only image is cited inside a subject definition",
          "<Subject 1> is a long red wool coat, shown in <Picture 2>.", subj_role["prompt"])
 check_not_in("a subject-only image earns no standalone picture entry",
              "<Picture 2> is", subj_role["prompt"])
+# refDesc and refNote are two different sentences in two different sections, and sharing
+# one key would mean a subject-defining image could carry one or the other but never both.
+check_in("a subject-only image keeps its own retention note as well as its description",
+         "<Subject 1>: fully_preserved - the cut and the brass buttons are kept.",
+         subj_role["prompt"])
 check("a subject-only image is no longer a keyframe",
       subj_role["ref_image_slots"][1].get("keyframe"), None)
 check("...while an untouched image still is",

--- a/test_plan.py
+++ b/test_plan.py
@@ -321,6 +321,44 @@ check("the whole refs-off prompt matches the base guide",
                       non_diegetic_music="N/A"),
               duration_f=240)["prompt"], BASE_GOLDEN)
 
+# ------------------------------------------------- the base guide's field list is closed
+# "Part Two: Three Core Fields (Required, in this order)" — and `summary` is not one of
+# them. It belongs to the reference guide, so on the fl2va path it would be a section H3
+# was never trained to read there. The box keeps its text for when the toolbar goes back.
+summary_off = compile(base_tl(["she enters"], summary="a woman walks through a market",
+                              task_type_override="video editing"), duration_f=240)
+check_not_in("no summary section on the fl2va path", "summary:", summary_off["prompt"])
+check_not_in("and no task-type prefix either", "video editing", summary_off["prompt"])
+check_in("the same box still reaches the ref2va prompt",
+         "summary: [keyframe completion] a woman walks through a market",
+         compile(tl([img(0, 144)], ref_mode="ON",
+                    summary="a woman walks through a market"))["prompt"])
+
+# non_diegetic_music is required by both guides, and "N/A" is their own value for having
+# none. overall_soundscape is not filled in the same way: there "N/A" claims the video was
+# asked to be silent, which is a statement only the user can make.
+check_in("an empty music box still writes the required field",
+         "non_diegetic_music: N/A", compile(tl([img(0, 144)]))["prompt"])
+check_in("and so does the reference path",
+         "non_diegetic_music: N/A", compile(tl([img(0, 144)], ref_mode="ON"))["prompt"])
+check("a prompt is never manufactured out of the default alone",
+      plan.plan_timeline({"prompt_format": "minimax"}, 0, 288, FPS)["prompt"], "video")
+check_in("an empty soundscape is called out rather than invented",
+         "overall_soundscape is empty",
+         " ".join(compile(tl([img(0, 144)]))["ref_warnings"]))
+check_not_in("and left alone once written", "overall_soundscape is empty",
+             " ".join(compile(tl([img(0, 144)],
+                                 overall_soundscape="Market chatter."))["ref_warnings"]))
+
+# 350-500 words is the reference guide's figure for its own detailed_description. The base
+# guide gives no word count at all, so the fl2va path must not cite one.
+long_shot = " ".join(["she walks"] * 300)
+check_not_in("no word-count warning on the fl2va path", "350-500",
+             " ".join(compile(tl([img(0, 144, prompt=long_shot)]))["ref_warnings"]))
+check_in("the reference path still warns past 500 words", "350-500",
+         " ".join(compile(tl([img(0, 144, prompt=long_shot)],
+                             ref_mode="ON"))["ref_warnings"]))
+
 # ------------------------------------------------- full-reference: the whole prompt
 # The one check that pins the *entire* output against references/ref-en.txt: section set
 # and order (subject_definitions, summary, retention_analysis, detailed_description, then

--- a/test_plan.py
+++ b/test_plan.py
@@ -395,6 +395,37 @@ check_in("the guide's own retention line can be reproduced exactly",
          "thick white fur, pointed ears, dark nose, and curved tail are retained.",
          samoyed["prompt"])
 
+# a <Video N> / <Audio N> declaration is prose, so a written one replaces it outright.
+# This is the only route to the guide's own shapes, which name things the timeline cannot
+# work out: "<Audio 1> is the voice-timbre reference for <Subject 1> (S1)".
+spoken = compile(tl([], ref_mode="ON",
+                    subjects=[{"images": [{"b64": "x", "name": "c.png"}],
+                               "description": "a woman in a red coat"}],
+                    audioSegments=[{"audioFile": "vo.wav", "start": 0, "length": 96,
+                                    "refDesc": "the voice-timbre reference for "
+                                               "<Subject 1> (S1)"}]),
+                 use_custom_audio=True)
+check_in("an audio clip can name the speaker it belongs to",
+         "<Audio 1> is the voice-timbre reference for <Subject 1> (S1).", spoken["prompt"])
+check_not_in("its generated declaration is gone, not doubled",
+             "is a reference audio clip", spoken["prompt"])
+check_in("a reference video's declaration can be written too",
+         "<Video 1> is the source video for the target video edit.",
+         compile(tl([], ref_mode="ON",
+                    motionSegments=[{"videoFile": "v.mp4", "fileName": "v.mp4",
+                                     "start": 0, "length": 120,
+                                     "refDesc": "the source video for the target video "
+                                                "edit"}]))["prompt"])
+check("the label is prepended, so it can never be wrong or doubled",
+      plan._declaration("<Audio 1>", "the voice reference", "generated"),
+      "<Audio 1> is the voice reference.")
+check("a sentence pasted with its own label is taken as written",
+      plan._declaration("<Audio 1>", "<Audio 1> is the synchronized track of <Video 1>",
+                        "generated"),
+      "<Audio 1> is the synchronized track of <Video 1>.")
+check("nothing written falls back to the generated sentence",
+      plan._declaration("<Audio 1>", "   ", "generated"), "generated")
+
 # ------------------------------------------------- Analyze output parsing
 check("split_analysis reads both labelled lines",
       plan.split_analysis("DESCRIPTION: A fluffy white Samoyed.\n"

--- a/test_plan.py
+++ b/test_plan.py
@@ -43,9 +43,11 @@ def check_not_in(name, needle, haystack):
     return ok
 
 
-def img(start, length, name="a.png", prompt="", end_frame=False):
-    return {"type": "image", "start": start, "length": length, "imageFile": name,
-            "fileName": name, "prompt": prompt, "isEndFrame": end_frame}
+def img(start, length, name="a.png", prompt="", end_frame=False, **extra):
+    d = {"type": "image", "start": start, "length": length, "imageFile": name,
+         "fileName": name, "prompt": prompt, "isEndFrame": end_frame}
+    d.update(extra)          # refRole / refKind / refNote / retention
+    return d
 
 
 def tl(segments, ref_mode="OFF", **extra):
@@ -112,12 +114,18 @@ short = compile(tl([img(0, 144, "a.png", prompt="she enters"),
 
 check_not_in("ref2va never says 'opening frame'", "opening frame", flush["prompt"])
 check_not_in("ref2va never says 'closing frame'", "closing frame", flush["prompt"])
-check_in("the opening image uses the guide's phrasing",
-         "[Shot 1] begins from <Picture 1>.", flush["prompt"])
-check_in("the closing image uses the guide's phrasing",
-         "[Shot 2] ends on <Picture 2>.", flush["prompt"])
+check_in("the opening image is declared as a first frame (guide 2.2)",
+         "<Picture 1> is the first frame of [Shot 1].", flush["prompt"])
+check_in("the closing image is declared as a last frame (guide 2.2)",
+         "<Picture 2> is the last frame of [Shot 2].", flush["prompt"])
+check_in("the opening image is also named in the body (guide 5.3)",
+         "The shot begins from <Picture 1>.", flush["prompt"])
+check_in("the closing image is also named in the body (guide 5.3)",
+         "The shot ends on <Picture 2>.", flush["prompt"])
 check_in("a middle image is a keyframe, with its time",
-         "The keyframe of [Shot 2] corresponds to <Picture 2>, at 6s.", short["prompt"])
+         "<Picture 2> is a keyframe of [Shot 2], at 6s.", short["prompt"])
+check_in("a middle image uses the guide's keyframe phrasing in the body",
+         "The shot's keyframe corresponds to <Picture 2>.", short["prompt"])
 check("the phrasing no longer flips on where a segment ends",
       ("begins from <Picture 1>" in flush["prompt"]
        and "begins from <Picture 1>" in short["prompt"]), True)
@@ -127,18 +135,20 @@ check_not_in("picture notes carry no filenames — the guide has no such notion"
 # an image whose own segment carries no text has no shot number in the body to point at
 noshot = compile(tl([img(0, 144, "a.png"), img(144, 144, "b.png")], ref_mode="ON"))
 check_in("without a numbered shot the opening image still reads naturally",
-         "The video begins from <Picture 1>.", noshot["prompt"])
+         "<Picture 1> is the first frame of the target video.", noshot["prompt"])
 check_in("without a numbered shot the closing image still reads naturally",
-         "The video ends on <Picture 2>.", noshot["prompt"])
+         "<Picture 2> is the last frame of the target video.", noshot["prompt"])
 check_not_in("no shot number is invented when the body has none",
              "[Shot", noshot["prompt"])
 mixed = compile(tl([img(0, 96, "a.png", prompt="she enters"),
                     img(96, 96, "b.png"),
                     img(192, 96, "c.png", prompt="she leaves")], ref_mode="ON"))
 check_in("shot numbers follow the body, which counts only shots with text",
-         "[Shot 2] ends on <Picture 3>.", mixed["prompt"])
+         "<Picture 3> is the last frame of [Shot 2].", mixed["prompt"])
 check_in("the untexted middle image falls back to a composition anchor",
          "<Picture 2> is a composition anchor at 4s.", mixed["prompt"])
+check_not_in("an anchor with no shot to sit in gets no body phrase",
+             "keyframe corresponds", mixed["prompt"])
 # the role itself must survive: it picks which frame of a video segment is taken,
 # and whether it is fitted to the canvas (minimax_director.py, ref_image_tensors)
 check("the closing image keeps its role on the slot",
@@ -182,9 +192,11 @@ withchar = compile(tl([img(0, 144, "a.png", prompt="she enters"),
 check("a character takes <Picture 1> ahead of the timeline",
       withchar["ref_image_slots"][0]["source"], "char")
 check_in("timeline images number after the character",
-         "[Shot 1] begins from <Picture 2>", withchar["prompt"])
-check_in("the character becomes a named subject",
-         "<Subject 1> is the character shown in <Picture 1>.", withchar["prompt"])
+         "<Picture 2> is the first frame of [Shot 1].", withchar["prompt"])
+check_in("a slot with a description becomes a named subject",
+         "<Subject 1> is a woman in a red coat, shown in <Picture 1>.", withchar["prompt"])
+check_not_in("a slot image earns no standalone <Picture> entry of its own (guide 2.2)",
+             "<Picture 1> is", withchar["prompt"])
 check("ref_images input slots sit between character and timeline",
       [s["source"] for s in compile(tl([img(0, 144)], ref_mode="ON", characters=chars),
                                     extra_ref_image_count=2)["ref_image_slots"]],
@@ -202,6 +214,263 @@ check_not_in("no raw @char1 survives", "@char1", sub["prompt"])
 sub_off = compile(tl([img(0, 144, "a.png", prompt="@char1 turns around")], characters=chars))
 check_in("@char1 resolves to the description with refs off",
          "a woman in a red coat turns around", sub_off["prompt"])
+
+nine = [{"images": [{"b64": "x", "name": "%d.png" % i}], "description": "subject %d" % i}
+        for i in range(9)]
+tags = compile(tl([img(0, 144, "a.png", prompt="@ref9 and @char1 meet")],
+                  ref_mode="ON", subjects=nine))
+check_in("@ref9 reaches the ninth slot", "<Subject 9> and <Subject 1> meet", tags["prompt"])
+check_not_in("no raw @ref tag survives", "@ref", tags["prompt"])
+
+# ------------------------------------------------- full-reference: the whole prompt
+# The one check that pins the *entire* output against references/ref-en.txt: section set
+# and order (subject_definitions, summary, retention_analysis, detailed_description, then
+# the sound fields), one declaration per label, one retention line per label, the markers
+# spelled exactly as the guide's fixed values, and the guide's in-body phrasing for frame
+# anchors. Substring checks elsewhere can all pass while the assembled prompt is wrong.
+spec_tl = {
+    "reference_mode": "ON", "prompt_format": "minimax",
+    "global_prompt": "The target video uses a realistic multi-camera sitcom style.",
+    "subjects": [
+        {"images": [{"b64": "x", "name": "shop.png"}], "kind": "environment",
+         "description": "the coffee shop with an exposed brick wall and an orange tufted sofa",
+         "retention": "fully_preserved"},
+        {"images": [{"b64": "y", "name": "dog.png"}], "kind": "animal",
+         "description": "a fluffy white Samoyed with a curved tail",
+         "retention": "partially_preserved"}],
+    "segments": [img(0, 120, "open.png", prompt="@ref1 is empty except for @ref2 on the sofa"),
+                 img(120, 120, "end.png", prompt="@ref2 lunges for the cookie")],
+    "audioSegments": [{"audioFile": "vo.wav", "start": 0, "length": 120,
+                       "retention": "fully_copy"}],
+    "overall_soundscape": "Soft indoor coffee-shop room tone throughout.",
+    "non_diegetic_music": "N/A"}
+SPEC_GOLDEN = (
+    "subject_definitions: "
+    "<Subject 1> is the coffee shop with an exposed brick wall and an orange tufted sofa, "
+    "shown in <Picture 1>. "
+    "<Subject 2> is a fluffy white Samoyed with a curved tail, shown in <Picture 2>. "
+    "<Picture 3> is the first frame of [Shot 1]. "
+    "<Picture 4> is the last frame of [Shot 2]. "
+    "<Audio 1> is a reference audio clip: its signal is reused in the target video."
+    "\n\n"
+    "summary: [keyframe completion + reference generation + audio reuse]"
+    "\n\n"
+    "retention_analysis:\n"
+    "<Subject 1> (appears in [Shot 1]): fully_preserved - "
+    "the layout, furnishing and lighting of <Subject 1> are retained.\n"
+    "<Subject 2> (appears in [Shot 1], [Shot 2]): partially_preserved - "
+    "<Subject 2> is still used, with some of its defined characteristics changed.\n"
+    "<Picture 3> ([Shot 1] first frame): fully_preserved - "
+    "the framing and composition of <Picture 3> are retained.\n"
+    "<Picture 4> ([Shot 2] last frame): fully_preserved - "
+    "the framing and composition of <Picture 4> are retained.\n"
+    "<Audio 1>: fully_copy - "
+    "<Audio 1> is reused as the target video's complete final audio track."
+    "\n\n"
+    "detailed_description: The target video uses a realistic multi-camera sitcom style. "
+    "[Shot 1] <Subject 1> is empty except for <Subject 2> on the sofa. "
+    "The shot begins from <Picture 3>. "
+    "[Shot 2] At 00:05.000, <Subject 2> lunges for the cookie. "
+    "The shot ends on <Picture 4>."
+    "\n\n"
+    "overall_soundscape: Soft indoor coffee-shop room tone throughout."
+    "\n\n"
+    "non_diegetic_music: N/A")
+check("the whole full-reference prompt matches the guide",
+      compile(spec_tl, duration_f=240, use_custom_audio=True)["prompt"], SPEC_GOLDEN)
+
+# ------------------------------------------------- old timelines still read
+# A workflow saved before subject kinds existed writes `characters` and carries neither a
+# kind nor a marker. It has to keep planning, and to plan the same way a timeline written
+# today with the defaults does — the defaults were chosen to reproduce the old wording.
+legacy_segs = [img(0, 144, "a.png", prompt="she enters"),
+               img(144, 144, "b.png", prompt="she arrives")]
+legacy = compile(tl(legacy_segs, ref_mode="ON",
+                    characters=[{"images": [{"b64": "x", "name": "c.png"}],
+                                 "description": "a woman in a red coat"}]))
+modern = compile(tl(legacy_segs, ref_mode="ON",
+                    subjects=[{"images": [{"b64": "x", "name": "c.png"}],
+                               "description": "a woman in a red coat",
+                               "kind": "person", "retention": "fully_preserved"}]))
+check("the old `characters` key plans identically to `subjects`",
+      legacy["prompt"], modern["prompt"])
+check("`subjects` wins when a timeline somehow carries both",
+      compile(tl([], ref_mode="ON",
+                 characters=[{"images": [{"b64": "x", "name": "old.png"}],
+                              "description": "the old one"}],
+                 subjects=[{"images": [{"b64": "y", "name": "new.png"}],
+                            "description": "the new one"}]))["prompt"].count("the new one"), 1)
+check("a slot with neither kind nor marker still gets both",
+      (plan.sanitize_kind(None), plan.sanitize_retention(None)),
+      (plan.SUBJECT_KIND_DEFAULT, plan.RETENTION_DEFAULT))
+
+# ------------------------------------------------- retention markers
+# "These markers are fixed English values in the output format" — so they are emitted
+# verbatim, and anything the editor might send that is not one of them is clamped rather
+# than passed through into the prompt.
+for marker in plan.RETENTION_VISIBLE:
+    got = compile(tl([img(0, 144)], ref_mode="ON",
+                     subjects=[{"images": [{"b64": "x", "name": "c.png"}],
+                                "description": "a woman", "retention": marker}]))["prompt"]
+    check_in("%s reaches the prompt verbatim" % marker, ": %s - " % marker, got)
+for marker in plan.RETENTION_AUDIO:
+    got = compile(tl([img(0, 144)], ref_mode="ON",
+                     audioSegments=[{"audioFile": "a.wav", "start": 0, "length": 96,
+                                     "retention": marker}]),
+                  use_custom_audio=True)["prompt"]
+    check_in("audio marker %s reaches the prompt verbatim" % marker,
+             "<Audio 1>: %s - " % marker, got)
+
+check("an invented marker is clamped, never emitted",
+      plan.sanitize_retention("very_strongly_preserved"), plan.RETENTION_DEFAULT)
+check("a visible marker is rejected on an audio label",
+      plan.sanitize_retention("attribute_transfer", audio=True), plan.RETENTION_AUDIO_DEFAULT)
+check("an audio marker is rejected on a visible label",
+      plan.sanitize_retention("fully_copy"), plan.RETENTION_DEFAULT)
+check("markers are matched case-insensitively",
+      plan.sanitize_retention("Weak_Reference"), "weak_reference")
+bogus = compile(tl([img(0, 144)], ref_mode="ON",
+                   subjects=[{"images": [{"b64": "x", "name": "c.png"}],
+                              "description": "a woman", "retention": "make_it_pop"}]))
+check_not_in("the invented marker never appears", "make_it_pop", bogus["prompt"])
+
+# a hand-written note replaces the generated one, and is punctuated if it wasn't
+noted = compile(tl([img(0, 144)], ref_mode="ON",
+                   subjects=[{"images": [{"b64": "x", "name": "c.png"}],
+                              "description": "a woman", "retention": "attribute_transfer",
+                              "retentionNote": "her coat colour moves to the stallholder"}]))
+check_in("a written retention note wins over the generated one",
+         "attribute_transfer - her coat colour moves to the stallholder.", noted["prompt"])
+
+# ------------------------------------------------- subject kinds
+# <Subject N> is not a character slot: "people, animals, or objects; scenes, backgrounds,
+# or environments; clothing, props, interfaces, or visual effects; styles, actions,
+# expressions, or poses".
+for kind, noun in (("environment", "the environment"), ("prop", "the prop"),
+                   ("style", "the visual style"), ("animal", "the animal")):
+    got = compile(tl([img(0, 144)], ref_mode="ON",
+                     subjects=[{"images": [{"b64": "x", "name": "c.png"}],
+                                "kind": kind}]))["prompt"]
+    check_in("a %s subject names itself as one" % kind,
+             "<Subject 1> is %s shown in <Picture 1>." % noun, got)
+check("an unknown kind falls back rather than inventing a noun",
+      plan.sanitize_kind("spaceship"), plan.SUBJECT_KIND_DEFAULT)
+check_in("a description replaces the kind noun entirely",
+         "<Subject 1> is a rain-slicked night market, shown in <Picture 1>.",
+         compile(tl([img(0, 144)], ref_mode="ON",
+                    subjects=[{"images": [{"b64": "x", "name": "c.png"}],
+                               "kind": "environment",
+                               "description": "a rain-slicked night market"}]))["prompt"])
+check_in("the retained detail follows the kind, not the word 'character'",
+         "the palette, texture and grade of <Subject 1> are retained.",
+         compile(tl([img(0, 144)], ref_mode="ON",
+                    subjects=[{"images": [{"b64": "x", "name": "c.png"}],
+                               "kind": "style"}]))["prompt"])
+
+# ------------------------------------------------- image reference roles
+# "If an image is used only to define a character, scene, costume, or style, do not create
+# a standalone picture entry. Instead, cite the image source inside the corresponding
+# <Subject N> definition."
+story = compile(tl([img(0, 144, "sb.png", prompt="the crowd parts", refRole="storyboard")],
+                   ref_mode="ON"))
+check_in("a storyboard image says which shot it plans and what it defines",
+         "<Picture 1> is a storyboard reference for [Shot 1], defining its viewpoint, "
+         "subject placement, and shot order.", story["prompt"])
+check_in("a storyboard image retains planning, not framing",
+         "the viewpoint, subject placement and shot order of <Picture 1> are retained.",
+         story["prompt"])
+
+subj_role = compile(tl([img(0, 144, "a.png", prompt="she enters"),
+                        img(144, 144, "coat.png", prompt="a wide shot", refRole="subject",
+                            refKind="clothing", refNote="a long red wool coat")],
+                       ref_mode="ON"))
+check_in("a subject-only image is cited inside a subject definition",
+         "<Subject 1> is a long red wool coat, shown in <Picture 2>.", subj_role["prompt"])
+check_not_in("a subject-only image earns no standalone picture entry",
+             "<Picture 2> is", subj_role["prompt"])
+check("a subject-only image is no longer a keyframe",
+      subj_role["ref_image_slots"][1].get("keyframe"), None)
+check("...while an untouched image still is",
+      subj_role["ref_image_slots"][0].get("keyframe"), plan.ROLE_FIRST)
+check("an unknown role falls back to the timeline's own reading",
+      plan.sanitize_ref_role("interpretive"), plan.REF_ROLE_AUTO)
+
+# ------------------------------------------------- summary task types
+prefix = lambda p: p["prompt"].split("summary: ")[1].split("\n")[0] if "summary: " in p["prompt"] else ""
+check("a plain keyframe timeline is keyframe completion",
+      prefix(compile(tl([img(0, 288, "a.png", prompt="she waits")], ref_mode="ON"))),
+      "[keyframe completion]")
+check("a slot image with no frame anchor is reference generation",
+      prefix(compile(tl([], ref_mode="ON", subjects=chars))), "[reference generation]")
+check("copied audio is reuse, referenced audio is reference",
+      (prefix(compile(tl([], ref_mode="ON"),
+                      use_custom_audio=True)),
+       prefix(compile(tl([], ref_mode="ON",
+                         audioSegments=[{"audioFile": "a.wav", "start": 0, "length": 96,
+                                         "retention": "partially_copy"}]),
+                      use_custom_audio=True))),
+      ("", "[audio reuse]"))
+check("task types combine in the guide's order and never repeat",
+      prefix(compile(tl([img(0, 144, "a.png", prompt="she enters"),
+                         img(144, 144, "b.png", prompt="a plan", refRole="storyboard")],
+                        ref_mode="ON",
+                        audioSegments=[{"audioFile": "a.wav", "start": 0, "length": 96}]),
+                     use_custom_audio=True)),
+      "[keyframe completion + reference generation + audio reference]")
+check("a reference video alone never claims video editing",
+      prefix(compile(tl([], ref_mode="ON",
+                        motionSegments=[{"videoFile": "v.mp4", "fileName": "v.mp4",
+                                         "start": 0, "length": 120}]))),
+      "[reference generation]")
+check("the override replaces the derived prefix",
+      prefix(compile(tl([img(0, 144)], ref_mode="ON",
+                        task_type_override="video continuation + keyframe completion"))),
+      "[video continuation + keyframe completion]")
+check("the override tolerates brackets the user typed",
+      plan.task_type_prefix([], [], [], "[video editing]"), "[video editing]")
+check("refs off writes no task prefix",
+      "summary:" in compile(tl([img(0, 144)]))["prompt"], False)
+check_in("a written summary follows the prefix",
+         "summary: [keyframe completion] She crosses the market.",
+         compile(tl([img(0, 288, "a.png", prompt="she waits")], ref_mode="ON",
+                    summary="She crosses the market."))["prompt"])
+
+# ------------------------------------------------- the cap leaves nothing dangling
+# The 12-file cap trims from the back. Every declaration and retention line has to
+# describe a reference that survived, and nothing may reference a dropped ordinal.
+# 9 images + 3 videos + 3 audios is 15 files, so three must go — audio first, then video,
+# then images from the back.
+capped = compile(tl([img(i * 20, 20, "%d.png" % i, prompt="shot %d" % i) for i in range(9)],
+                    ref_mode="ON",
+                    motionSegments=[{"videoFile": "v%d.mp4" % i, "fileName": "v%d.mp4" % i,
+                                     "start": 0, "length": 96} for i in range(3)],
+                    audioSegments=[{"audioFile": "a%d.wav" % i, "start": 0, "length": 96}
+                                   for i in range(3)]),
+                 use_custom_audio=True)
+total = (len(capped["ref_image_slots"]) + len(capped["ref_video_segs"])
+         + len(capped["ref_audio_segs"]))
+check("the total-file cap trims to the model card's limit", total, plan.MAX_REF_FILES)
+check("audio is dropped before video or images", len(capped["ref_audio_segs"]), 0)
+check("the images all survive", len(capped["ref_image_slots"]), plan.MAX_REF_IMAGES)
+check_not_in("no dropped audio is left declared", "<Audio 1>", capped["prompt"])
+
+# The per-type caps mean images can never actually be trimmed: images + videos is at most
+# 12 on its own, so the excess is never larger than the audio bucket that is emptied
+# first. Assert that rather than pretend to test a path nothing can reach — and check
+# directly that declarations are built from the surviving slots, which is what makes the
+# ordering safe if a cap ever moves.
+check("the excess never outgrows the audio bucket that absorbs it",
+      [(i, v, a) for i in range(plan.MAX_REF_IMAGES + 1)
+       for v in range(plan.MAX_REF_VIDEOS + 1) for a in range(plan.MAX_REF_AUDIOS + 1)
+       if i + v + a - plan.MAX_REF_FILES > a], [])
+
+only_two = plan.build_subject_definitions(
+    [], [{"source": "timeline", "ref_role": "auto", "picture_role": plan.ROLE_FIRST,
+          "kind": "person", "retention": "fully_preserved", "note": "",
+          "shot_no": 1, "at": "0s"}], [], [])
+check("declarations describe exactly the slots handed in", len(only_two[0]), 1)
+check_not_in("nothing is declared for a slot that was trimmed away",
+             "<Picture 2>", " ".join(only_two[0]))
 
 # ------------------------------------------------- issue #7: soundscape / music
 audio = tl([img(0, 144)], ref_mode="ON")

--- a/test_plan.py
+++ b/test_plan.py
@@ -758,6 +758,27 @@ check("split_audio_music leaves a prompt without labels alone",
 check("split_audio_music takes a label only at the start of a line",
       plan.split_audio_music("a car with no audio: here")[1], "")
 
+# ------------------------------------------------- reference video decode budget
+# Reference frames are VAE-encoded whole and ride through every sampling step, so the
+# decode size is the biggest lever on an out-of-memory render. Lowering the short edge has
+# to scale the area with it, not square it away.
+check("the default budget is exactly the native canvas",
+      int(plan.REF_VIDEO_SHORT_EDGE ** 2 * plan.REF_VIDEO_ASPECT_BUDGET), 768 * 1344)
+check("halving the short edge quarters the pixel budget",
+      round((384 ** 2) / (768 ** 2), 3), 0.25)
+check("the offered sizes start at the native canvas and only go down",
+      (plan.REF_VIDEO_SIZES[0],
+       list(plan.REF_VIDEO_SIZES) == sorted(plan.REF_VIDEO_SIZES, reverse=True)),
+      (plan.REF_VIDEO_SHORT_EDGE, True))
+# The loader now honours a trim shorter than the model card's 2s instead of quietly
+# extending it back up — so the warning is the only thing left saying it is short.
+check_in("a clip trimmed under 2s is reported, not silently extended",
+         "H3 wants 2-15s per clip",
+         " ".join(compile(tl([], ref_mode="ON",
+                             motionSegments=[{"videoFile": "v.mp4", "fileName": "v.mp4",
+                                              "start": 0, "length": 24}])
+                          )["ref_warnings"]))
+
 # ---------------------------------------------------------------- comfyui format
 cf = compile(tl([img(0, 144, "a.png"), img(144, 141, "b.png")], ref_mode="ON",
                 prompt_format="comfyui"))


### PR DESCRIPTION
Closes #8 

Closes #10

### Follow H3 prompt format for base and ref models

Brings the node up to the reference model H3 documents, in ref-en.txt (https://github.com/MiniMax-AI/MiniMax-H3/blob/main/skills/h3-prompt-writing/references/ref-en.txt) and base-en.txt (https://github.com/MiniMax-AI/MiniMax-H3/blob/main/skills/h3-prompt-writing/references/base-en.txt).

Until now a reference image was always a character, always followed as tightly as possible, and a timeline image was always a frame anchor. Two output sections were structurally missing: subject_definitions never declared <Picture N> entries, and retention_analysis emitted prose where the guide specifies fixed marker values.

What a reference can now be:

- Not just a character — slots carry a kind (person, place, garment, style, pose…), and the stepper sets how many there are, 1 to 9, three on a fresh node. `@ref1`…`@ref9`; `@char1`…`@char9` still resolve.
- Not just "follow it exactly" — each reference carries one of the guide's four retention markers, written verbatim. Audio keeps its own set.
- Not always a `<Picture N>` — an image that only defines a character or a style is cited inside its <Subject N> line instead, and stops being cropped as a keyframe.
- Not always an image — a slot works with a description alone, which is the only kind of subject the fl2va path can carry. That path also gains "called", the handle used after a subject's first appearance, per the base guide's rule.
- Both sentences are writable — describes feeds subject_definitions, retained feeds retention_analysis. Empty falls back to a generated sentence.

Also:

- speakers and `<d>` dialogue tags from `@ref1 says: …`;
- a summary section with a derived [task type];
- reference videos with adjustable start, frame count and size for better memory efficiency.

Built on 0.1.6, and changing three things it shipped:

- `<Audio N> is the voice-timbre reference for <Subject N> (Sx)` loses the `(Sx)`. It wrote the subject number as the speaker ID, but the guide assigns those "according to the order of actual vocal events in the target video" — its own example line is `<Subject 3> (S1)`. The ID is written where the subject actually speaks.
- A `ref_image_notes` line becomes that picture's entry in subject_definitions and earns it one in retention_analysis, instead of a flat note appended to the reference list.
- The subject-slot stepper is rebuilt above the resizable panel and persists its count.

Fixed along the way:

- the chain node ignored the ref_images socket entirely;
- the live preview showed picture numbers the render disagreed with;
- a reference video the browser can't decode did nothing (now probed server-side with PyAV);
- summary leaked into fl2va prompts, and `@ref` tags written in it reached the model as literal text;
- the Voice of menu named subjects by slot, so an empty slot 1 made "Subject 2" bind `<Subject 1>`, and it never re-read itself when a reference image was added or deleted. plan_timeline now returns subject_of_slot, so the editor labels the menu from the planner instead of repeating the numbering rule.

Compatibility. Prompt output changes for any workflow using references — that is the point. Old timelines load: the previous characters key plans identically to today's defaults, pinned by a test.

Testing. test_plan.py goes from 123 to 263 offline checks, including whole-prompt goldens pinned against both guides' worked examples.