### PR TITLE
fix(director): keep dialogue in place and reuse speaker IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,61 @@
 # Changelog
 
+## Unreleased
+
+- **A voice reference's declaration ends on the speaker's global ID**, which is what the
+  guide means by "reuse that speaker's global ID in the definition":
+
+  ```
+  subject_definitions:  <Audio 1> is the voice-timbre reference for <Subject 2> (S2).
+  ```
+
+  The ID is the speaking order rather than the subject number, so it cannot be known when
+  that sentence is written — it is filled in once the numbering pass has walked the finished
+  body. A subject who never speaks has no ID to reuse and the sentence ends on the label,
+  which already says whose voice the clip is. A hand-written declaration gets the same
+  treatment when it names the subject, and is left alone when it writes an ID of its own.
+
+- **A spoken line stays where it was written.** Dialogue is lifted out of a shot prompt to be
+  rendered and was then appended to the end of the shot, which only looked right when the
+  line already came last. A line with prose after it moved:
+
+  ```
+  @ref1: before mid segment          [Shot 1] mid segment. a woman (S1) says,
+  mid segment                    →     <d>[English] before mid segment</d> a woman (S1)
+  @ref1: after mid segment             says, <d>[English] after mid segment</d>
+  ```
+
+  It is now put back where it sat, which is how the guide writes a shot — its own Shot 1 goes
+  action, the line that action motivates, then more action. The same pass decides both
+  orderings the guide cares about, so they can no longer disagree: which mention of a subject
+  is its *first* — and so is named in full rather than by its **called** name — and the order
+  of vocal events that hands out `(Sx)`. A frame anchor still rides with the prose rather than
+  trailing the shot, since a spoken line is not something a shot "begins from". `</d>` no
+  longer picks up a full stop it never needed.
+
+- **The live preview reports a line that reads as dialogue and stayed prose.** The colon is
+  what makes a tagged line dialogue, and `@ref1 says "hello sir"` — the natural thing to
+  type — has none, so it reached the model as narration: no speaker ID, no `<d>[Language]
+  …</d>`, and nothing for an `<Audio N>` voice reference to reuse. The line is not
+  reinterpreted, because prose quotes things nobody says out loud, but it is no longer
+  silent:
+
+  ```
+  [Shot 2] `@ref1 says "hello sir"` reads as dialogue but has no colon, so it stayed
+  narration — no speaker ID, no <d>[Language] …</d>. Dialogue is `@ref1 <how it is said>:
+  the words`.
+  ```
+
+  `@char1 says: hello` is reported the same way: the alias resolves to a subject label
+  everywhere, but only `@refN` speaks.
+
+- **Two required fields are reported when they are empty.** `detailed_description` joins
+  `overall_soundscape`, which was already checked — and unlike the soundscape it has no
+  `N/A`, so an empty one leaves the section out of the prompt entirely rather than visibly
+  blank. A voice reference bound to a subject who never speaks is reported too, naming the
+  tag that would give them a line: the declaration has no `(Sx)` to reuse in that case, which
+  is correct and reads like a bug.
+
 ## 0.2.1
 
 Four reports, and one of them was right about something this pack had been saying wrongly

--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ see the exact prompt the model will receive while you are still editing it.
 
 ## News
 
+**Unreleased** — a **spoken line stays where it was written** instead of being appended to
+the end of its shot, so first appearance and `(Sx)` follow one order, and a voice
+reference's declaration ends on the speaker ID the guide reuses. The live preview reports a
+line that reads as dialogue and stayed prose, and the two required fields that were empty.
+
 **0.2.1** · 2026-08-16 — **width and height can be wired in** from a resolution node, as
 connection-only inputs beside `start` / `end` / `duration`. The **Analyze** button can now
 reach a cloud endpoint: there is an API-key field, kept in ComfyUI's settings and never in
@@ -460,8 +465,8 @@ doubled. Paste a whole line that already starts with its label and it is taken a
 
 One such relationship has its own control rather than a box: an audio clip's **Voice of**
 picks a subject, and the declaration becomes the guide's `<Audio 1> is the voice-timbre
-reference for <Subject 1>.` A **describes** line still wins over it, for when the binding
-is not the whole story.
+reference for <Subject 1> (S1).` A **describes** line still wins over it, for when the
+binding is not the whole story.
 
 Frame anchors and storyboard references are the one exception: they have **retained**
 alone. Their declaration states where the image sits in the video (`<Picture 2> is the
@@ -499,6 +504,38 @@ Only a line that *starts* with a tag counts, so prose that merely mentions `@ref
 contains a colon is left alone — the same rule the `Audio:` / `Music:` lines follow. A shot
 whose only content is a spoken line is still a numbered shot.
 
+**The colon is what makes it dialogue**, and quotes are not a substitute:
+
+```
+@ref1 says "hello sir"   →  <Subject 1> says "hello sir".            prose
+@ref1 says: hello sir    →  <Subject 1> (S1) says, <d>[English] hello sir</d>
+```
+
+The first line reaches the model as narration — no speaker ID, no `<d>` tag, and nothing for
+an `<Audio N>` voice reference to reuse. Nothing is silently reinterpreted, because a line
+that quotes something is not always a line somebody speaks, but the preview now says when a
+line reads as dialogue and stayed prose. Dialogue also wants `@refN`: `@char1` and
+`@character1` still resolve to a subject *label* everywhere, but they do not speak, and the
+preview says that too.
+
+**A spoken line stays where you wrote it.** Dialogue is lifted out of the prompt to be
+rendered, then put back in the same place, so a line between two paragraphs stays between
+them — which is how the guide writes a shot: action, the line it motivates, then more action.
+
+```
+@ref1: before mid segment
+mid segment
+@ref1: after mid segment
+
+→ [Shot 1] a woman (S1) says, <d>[English] before mid segment</d> mid segment.
+  a woman (S1) says, <d>[English] after mid segment</d>
+```
+
+Whichever comes first in the shot — prose or a spoken line — is where the subject is named in
+full, and **called** takes over from there. `</d>` closes a tag rather than ending a sentence,
+so the next words run straight out of it with no full stop, exactly as the guide's example
+does.
+
 `<scenetrans>` and `<cutoff>`, for dialogue crossing a cut or speech that is cut short, are
 passed through untouched if you type them.
 
@@ -531,10 +568,14 @@ work away; the tooltip says so.
 
 An **audio clip on the timeline can name whose voice it is**: pick a subject in the clip's
 info panel and the prompt says so in the guide's own words — `<Audio 1> is the voice-timbre
-reference for <Subject 1>.` Leave it unset and the clip stays a general voice reference, as
-before. The guide's own example ends that sentence with a speaker ID, `(S1)`; this does not,
-because IDs are handed out in the order voices are actually heard and a subject with a voice
-reference need never speak. Where the subject does speak, the ID is on the line itself.
+reference for <Subject 1> (S1).` Leave it unset and the clip stays a general voice reference.
+The speaker ID at the end is the subject's global one, so it is the *speaking* order and not
+the subject number: bind the clip to a subject who talks second and the line ends
+`<Subject 2> (S2)`. The guide is firm that this sentence "reuses the same `(Sx)` but never
+assigns a new one independently", so a subject who never speaks has no ID to reuse and the
+sentence ends on the label alone — which still says whose voice the clip is. The preview says
+when that happens, since a voice reference for someone with no line is usually a missing line
+rather than a deliberate choice.
 
 **Analyze** is optional and off the critical path. It sends the slot image to a vision
 model and pastes back a one-line description, so `@ref1` still means something in

--- a/minimax_plan.py
+++ b/minimax_plan.py
@@ -493,10 +493,10 @@ def build_subject_definitions(subject_slots, ref_image_slots, ref_video_segs,
         # A clip can name the subject whose voice it carries, which is the one thing a
         # written sentence should not have to spell out: with two voice references and no
         # binding there is nothing in the prompt saying which voice belongs to whom
-        # (issue #10). The guide's sentence ends "<Subject 1> (S1)", but the speaker ID is
-        # not knowable here — IDs are assigned in vocal-event order, further down, and this
-        # subject may never speak at all. The label alone is unambiguous, and the ID is
-        # written where it belongs, on the line itself.
+        # (issue #10). The guide ends that sentence with the speaker's global ID,
+        # "<Subject 1> (S1)", which is not knowable here — IDs are assigned in vocal-event
+        # order, further down. apply_speaker_ids fills it in afterwards, which is what
+        # `line_index` is for.
         subject = subject_of_slot.get(_audio_subject_slot(seg))
         if subject:
             # the generated declaration has to agree with the marker: telling the model to
@@ -511,8 +511,12 @@ def build_subject_definitions(subject_slots, ref_image_slots, ref_video_segs,
                          % (label, "its signal is reused in the target video." if copied
                             else "follow its voice and timbre."))
         lines.append(_declaration(label, seg.get("refDesc"), generated))
+        # `voice_of` rather than `subject`: build_retention_analysis reads that key as "this
+        # entry *is* a subject" and would replace the audio line's "(voice of <Subject 2>)"
+        # with a shot list belonging to somebody else.
         labels.append({"label": label, "kind": "audio", "audio": True, "marker": marker,
                        "note": (seg.get("refNote") or "").strip(),
+                       "voice_of": subject, "line_index": len(lines) - 1,
                        "where": "voice of <Subject %d>" % subject if subject else ""})
 
     return lines, subject_of_slot, labels, pic_texts, subject_notes
@@ -652,30 +656,24 @@ def compile_storyboard_minimax(global_prompt, shots, soundscape="", music="",
     if gp:
         body.append(gp)
     for index, shot in enumerate(written):
-        text = shot["prompt"].strip()
+        pieces = list(shot.get("pieces") or [])
         # guide 5.3: a frame anchor is named in the shot itself, in natural phrasing, as
-        # well as being declared above. It goes after the shot's own text: a later shot
-        # opens "At 00:05.000, " and the sentence has to continue out of that comma, which
-        # a capitalised "The shot begins from…" cannot do.
+        # well as being declared above. It rides with the prose rather than trailing the whole
+        # shot — it says how the shot opens, and a spoken line is not something a shot "begins
+        # from" — so it goes after the last prose piece, which for a shot that is all prose is
+        # where it has always gone.
         phrases = " ".join(shot.get("ref_phrases") or [])
         if phrases:
-            if text:
-                if not text.endswith((".", "!", "?", ",", ";", ":")):
-                    text += "."
-                text = "%s %s" % (text, phrases)
-            elif index:
-                # nothing of the user's own to open on, and a later shot opens
+            last_prose = max((i for i, (kind, _) in enumerate(pieces) if kind == "prose"),
+                             default=-1)
+            if last_prose < 0:
+                # nothing of the user's own to attach to, and a later shot opens
                 # "At 00:05.000, " — so our own sentence has to continue out of that comma
-                text = phrases[0].lower() + phrases[1:]
+                pieces.insert(0, ("prose", phrases if not index
+                                  else phrases[0].lower() + phrases[1:]))
             else:
-                text = phrases
-        # the guide's example ends a shot on its spoken line, after the action that
-        # motivates it
-        spoken = (shot.get("dialogue_text") or "").strip()
-        if spoken:
-            if text and not text.endswith((".", "!", "?")):
-                text += "."
-            text = ("%s %s" % (text, spoken)).strip()
+                pieces.insert(last_prose + 1, ("prose", phrases))
+        text = join_shot_pieces([piece for _, piece in pieces])
         if index == 0:
             body.append("[Shot 1] %s" % text)
         else:
@@ -768,21 +766,38 @@ DESCRIPTION_MIN_WORDS = 350
 DESCRIPTION_MAX_WORDS = 500
 
 
+# Where a lifted dialogue line sat, left behind in the prose so render_shot can put the
+# spoken line back exactly there. A shot is not a paragraph followed by its dialogue — the
+# guide's own Shot 1 goes action, spoken line, more action — so a line written between two
+# paragraphs has to stay between them. Invisible to the user: every mark is consumed during
+# rendering, and any \x00 in the incoming text is dropped before one can be confused for it.
+DIALOGUE_MARK = "\x00%d\x00"
+DIALOGUE_MARK_RE = re.compile("\x00(\\d+)\x00")
+
+# The guide runs an action straight out of a spoken line with no punctuation between them:
+# "…<d>[English] Hey! Watch your dog!</d> She closes her lips…"
+DIALOGUE_CLOSE = "</d>"
+
+
 def split_dialogue(text):
     """Lift `@ref1 says: …` lines out of a shot prompt into structured vocal events.
 
-    Returns (remaining prose, events). Speaker IDs are deliberately *not* assigned here:
-    the guide numbers them "according to the order of actual vocal events in the target
-    video", which is a property of the whole timeline, not of one shot.
+    Returns (remaining prose, events). The prose keeps a DIALOGUE_MARK where each lifted line
+    sat, so the shot can be reassembled in the order it was written.
+
+    Speaker IDs are deliberately *not* assigned here: the guide numbers them "according to the
+    order of actual vocal events in the target video", which is a property of the whole
+    timeline, not of one shot.
     """
     if not text:
         return text or "", []
     kept, events = [], []
-    for line in text.splitlines():
+    for line in text.replace("\x00", "").splitlines():
         match = DIALOGUE_RE.match(line.strip())
         if not match:
             kept.append(line)
             continue
+        kept.append(DIALOGUE_MARK % len(events))
         events.append({
             "slot": int(match.group("slot")) if match.group("slot") else None,
             "voice": (match.group("voice") or "").strip() or None,
@@ -792,6 +807,45 @@ def split_dialogue(text):
             "line": match.group("line").strip(),
         })
     return "\n".join(kept).strip(), events
+
+
+# Two ways a line that was meant to be spoken reaches the model as narration instead:
+#
+#   @ref1 says "hello sir"     no colon, so DIALOGUE_RE never claimed it
+#   @char1 says: hello sir     an alias substitute_char_tags resolves and DIALOGUE_RE does not
+#
+# Both are reported rather than repaired. The colon is the whole rule, and widening it to take
+# quoted text would claim prose that quotes something nobody says out loud.
+#
+# The quoted words have to *end* the line, which is where dialogue puts them — the same place
+# the colon form puts them. That is what separates the near-miss from ordinary prose that
+# happens to quote a thing: `@ref1 reads the sign "Closed" and frowns` carries on afterwards
+# and is left alone. A line that genuinely ends on a quoted noun — `@ref1 points at the sign
+# "CLOSED"` — is still caught, which costs one sentence in the warnings strip and changes
+# nothing about the prompt. A verb list would settle those, and would break on the first
+# prompt written in another language.
+NEAR_MISS_QUOTE_RE = re.compile(
+    u"^@(?:ref|char|character)\\d+[^:\"“«]*[\"“«][^\"”»]+[\"”»][\\s.!?,;]*$",
+    re.IGNORECASE)
+NEAR_MISS_ALIAS_RE = re.compile(r"^@(?:char|character)(\d+)[^:]*:\s*\S", re.IGNORECASE)
+
+
+def near_miss_dialogue(text):
+    """Lines in a shot's prose that read as dialogue but did not become any.
+
+    Returns (line, reason) pairs, `reason` being "colon" or "alias" — enough for the caller to
+    say which rule was missed without this having to know about shot numbering or warnings.
+    """
+    found = []
+    for line in (text or "").splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if NEAR_MISS_ALIAS_RE.match(stripped):
+            found.append((stripped, "alias"))
+        elif ":" not in stripped and NEAR_MISS_QUOTE_RE.match(stripped):
+            found.append((stripped, "colon"))
+    return found
 
 
 def shot_has_text(shot):
@@ -804,44 +858,113 @@ def shot_has_text(shot):
     return bool((shot.get("prompt") or "").strip() or shot.get("dialogue"))
 
 
-def assign_speakers(shots, label_for_slot):
-    """Number speakers across the timeline and render each line the way the guide asks.
+def render_event(event, ids, label_for_slot):
+    """One vocal event, numbering any speaker met here for the first time.
 
-    `(Sx)` is assigned once per speaker, in the order vocal events actually occur, and
-    reused at every later event by that speaker — so the same person keeps one ID across
-    cuts, exactly as <Subject N> does. Verbal content carried by reused audio names
-    <Audio N> as its source and gets no ID at all: the guide is explicit that a cue inside
-    a soundtrack has no independent vocal source to number.
+    `(Sx)` is assigned once per speaker, in the order vocal events actually occur, and reused
+    at every later event by that speaker — so the same person keeps one ID across cuts, exactly
+    as <Subject N> does. Verbal content carried by reused audio names <Audio N> as its source
+    and gets no ID at all: the guide is explicit that a cue inside a soundtrack has no
+    independent vocal source to number.
     """
-    ids = {}
-    for shot in shots:
-        render_speakers(shot, ids, label_for_slot)
-    return ids
+    tag = "<d>[%s] %s</d>" % (event["language"], event["line"])
+    if event["audio"]:
+        return "<Audio %d> carries %s" % (event["audio"], tag)
+    if event["slot"]:
+        who = label_for_slot(event["slot"]) or "an unnamed speaker"
+        key = ("slot", event["slot"])
+    else:
+        who = event["voice"] or "an unnamed speaker"
+        key = ("voice", who.strip().lower())
+    if key not in ids:
+        ids[key] = len(ids) + 1
+    return "%s (S%d) %s, %s" % (who, ids[key], event["delivery"], tag)
 
 
-def render_speakers(shot, ids, label_for_slot):
-    """One shot's vocal events, numbering any speaker met here for the first time.
+def join_shot_pieces(parts):
+    """Run a shot's pieces together, supplying the full stop the next one needs.
 
-    Split out of assign_speakers so a caller can interleave it with the prose
-    substitution, shot by shot: which mention of a subject is its *first* depends on the
-    prose and the dialogue together, not on either one read to the end on its own.
+    A piece ending on `</d>` is left alone — the guide continues straight out of a spoken line
+    into the next action, with no punctuation between them.
     """
-    rendered = []
-    for event in shot.get("dialogue") or []:
-        tag = "<d>[%s] %s</d>" % (event["language"], event["line"])
-        if event["audio"]:
-            rendered.append("<Audio %d> carries %s" % (event["audio"], tag))
+    out = ""
+    for part in parts:
+        part = (part or "").strip()
+        if not part:
             continue
-        if event["slot"]:
-            who = label_for_slot(event["slot"]) or "an unnamed speaker"
-            key = ("slot", event["slot"])
+        if not out:
+            out = part
+            continue
+        if not out.endswith((".", "!", "?", ",", ";", ":", DIALOGUE_CLOSE)):
+            out += "."
+        out += " " + part
+    return out
+
+
+def render_shot(shot, values, later=None, seen=None, ids=None, label_for_slot=None):
+    """Resolve one shot's tags and spoken lines, in the order they were written.
+
+    A single pass, because both orderings the guide cares about are properties of the finished
+    shot read left to right: "the first appearance" of a subject, which decides whether it is
+    named in full or by its short name, and "the order of actual vocal events", which decides
+    `(Sx)`. Reading all the prose and then all the dialogue gets both wrong for a shot whose
+    dialogue is not simply trailing — and moves the line, which is worse than either.
+
+    Fills `shot["pieces"]`, ("prose"|"dialogue", text) in written order, and `shot["text"]`,
+    the pieces run together. The pieces are kept so a frame anchor can be placed against the
+    prose instead of after a spoken line.
+    """
+    events = shot.get("dialogue") or []
+    pieces = []
+    # re.split with one group alternates prose, mark, prose, mark, … so odd indices are marks
+    for index, part in enumerate(DIALOGUE_MARK_RE.split(shot.get("prompt") or "")):
+        if index % 2:
+            slot = int(part)
+            text = (render_event(events[slot], ids, label_for_slot)
+                    if 0 <= slot < len(events) else "")
+            kind = "dialogue"
         else:
-            who = event["voice"] or "an unnamed speaker"
-            key = ("voice", who.strip().lower())
-        if key not in ids:
-            ids[key] = len(ids) + 1
-        rendered.append("%s (S%d) %s, %s" % (who, ids[key], event["delivery"], tag))
-    shot["dialogue_text"] = " ".join(rendered)
+            text = substitute_char_tags(part, values, later, seen).strip()
+            kind = "prose"
+        if text:
+            pieces.append((kind, text))
+    shot["pieces"] = pieces
+    shot["text"] = join_shot_pieces([text for _, text in pieces])
+
+
+def apply_speaker_ids(lines, labels, speaker_of_subject):
+    """Fill each voice clip's declaration in with the speaker's global ID.
+
+    The guide asks a bound `<Audio N>` to "reuse that speaker's global ID in the definition":
+    `<Audio 1> is the voice-timbre reference for <Subject 1> (S1).` The ID cannot be known
+    when that sentence is written — speakers are numbered in the order vocal events occur,
+    which is a property of the finished body, not of one declaration — so the line is patched
+    here, once the numbering pass has run.
+
+    A subject that never speaks has no ID and its declaration keeps the label alone, which is
+    still an unambiguous binding. `(Sx)` deliberately does not reach retention_analysis: the
+    guide reserves it for detailed_description, and only these declaration lines are touched.
+    """
+    for entry in labels:
+        subject = entry.get("voice_of")
+        index = entry.get("line_index")
+        if not subject or index is None:
+            continue
+        speaker = speaker_of_subject.get(subject)
+        if not speaker:
+            continue
+        line = lines[index]
+        # a sentence that spells out its own ID is taken as written, the same way
+        # _declaration takes a sentence that opens with its own label
+        if SPEAKER_ID_RE.search(line):
+            continue
+        # A written sentence need not name the subject it was bound to, and an ID attached to
+        # nothing reads as belonging to whoever is named instead. The closing ">" keeps
+        # <Subject 1> from matching inside <Subject 10>.
+        ref = "<Subject %d>" % subject
+        if ref not in line:
+            continue
+        lines[index] = line.replace(ref, "%s (S%d)" % (ref, speaker), 1)
 
 
 ANALYSIS_DESC_PREFIX = "description:"
@@ -902,10 +1025,10 @@ def compile_storyboard(global_prompt, shots, total_seconds):
     written = [s for s in shots if shot_has_text(s)]
 
     # Dialogue was lifted out of the prompt before this format ever saw it, so it has to be
-    # put back or a spoken line would vanish from a comfyui-format prompt entirely.
+    # put back or a spoken line would vanish from a comfyui-format prompt entirely. render_shot
+    # has already done that, in the order it was written.
     def body(shot):
-        parts = [(shot["prompt"] or "").strip(), (shot.get("dialogue_text") or "").strip()]
-        return " ".join(p for p in parts if p)
+        return (shot.get("text") or "").strip()
 
     parts = []
     gp = (global_prompt or "").strip()
@@ -1277,6 +1400,26 @@ def plan_timeline(tdata, win_start, duration_frames, fps, global_prompt="",
             for slot, subject in subject_of_slot.items():
                 char_tag_values[slot] = "<Subject %d>" % subject
 
+    # A line meant to be spoken that the dialogue rule did not claim, reported before the
+    # tags resolve — afterwards there is no "@ref1" left to point at, only the label it
+    # became. The shot number is the body's, which counts only shots carrying text.
+    near_miss_no = 0
+    for shot in shots:
+        if not shot_has_text(shot):
+            continue
+        near_miss_no += 1
+        for line, reason in near_miss_dialogue(shot["prompt"]):
+            if reason == "alias":
+                ref_warnings.append(
+                    "[Shot %d] `%s` names a subject with @char, which does not speak. Write "
+                    "@ref%s for a spoken line, so it gets a speaker ID and <d>[Language] …</d>."
+                    % (near_miss_no, line, NEAR_MISS_ALIAS_RE.match(line).group(1)))
+            else:
+                ref_warnings.append(
+                    "[Shot %d] `%s` reads as dialogue but has no colon, so it stayed narration "
+                    "— no speaker ID, no <d>[Language] …</d>. Dialogue is `@ref1 <how it is "
+                    "said>: the words`." % (near_miss_no, line))
+
     # Left to right through the finished video — `summary`, then the global block, then
     # each shot in turn, its prose before its dialogue. `seen_slots` is what makes "the
     # first appearance" mean the first one anywhere rather than the first one in this
@@ -1313,9 +1456,17 @@ def plan_timeline(tdata, win_start, duration_frames, fps, global_prompt="",
 
     speaker_ids = {}
     for shot in shots:
-        shot["prompt"] = substitute_char_tags(shot["prompt"], char_tag_values,
-                                              char_tag_later, seen_slots)
-        render_speakers(shot, speaker_ids, label_for_slot)
+        render_shot(shot, char_tag_values, char_tag_later, seen_slots, speaker_ids,
+                    label_for_slot)
+
+    # Now that every speaker has an ID, the voice-reference declarations can end the way the
+    # guide ends them. Only the panel-slot speakers map onto subjects — a @voice(…) speaker
+    # has no <Subject N> to be the timbre reference for.
+    speaker_of_subject = {subject_of_slot[slot]: speaker
+                          for (kind, slot), speaker in speaker_ids.items()
+                          if kind == "slot" and slot in subject_of_slot}
+    apply_speaker_ids(subject_lines, ref_labels, speaker_of_subject)
+    slot_of_subject = {subject: slot for slot, subject in subject_of_slot.items()}
 
     # only the minimax format has a detailed_description to measure; the key exists either
     # way so every caller can read it without checking the format first
@@ -1345,7 +1496,7 @@ def plan_timeline(tdata, win_start, duration_frames, fps, global_prompt="",
                 continue
             written_no += 1
             # dialogue counts: a subject that only ever speaks still appears in that shot
-            body = "%s %s" % (shot["prompt"] or "", shot.get("dialogue_text") or "")
+            body = shot.get("text") or ""
             for entry in ref_labels:
                 num = entry.get("subject")
                 if num and entry["label"] in body:
@@ -1403,8 +1554,7 @@ def plan_timeline(tdata, win_start, duration_frames, fps, global_prompt="",
         # warning area stops being read at all. Only overshooting the range is called out,
         # where the prompt really has outgrown what the guide describes.
         description_words = len(global_prompt.split()) + sum(
-            len(("%s %s" % (s["prompt"] or "", s.get("dialogue_text") or "")).split())
-            for s in shots if shot_has_text(s))
+            len((s.get("text") or "").split()) for s in shots if shot_has_text(s))
         #
         # Only on the reference path: 350-500 is that guide's figure for its own
         # detailed_description. The base guide gives no word count at all, so citing one
@@ -1423,6 +1573,28 @@ def plan_timeline(tdata, win_start, duration_frames, fps, global_prompt="",
             ref_warnings.append(
                 "overall_soundscape is empty; the guide lists it as a required field. "
                 "Describe the ambience, or write N/A if the video is meant to be silent.")
+
+        # The same rule for the field that carries the whole video. Unlike the soundscape
+        # there is no N/A for it: a prompt with no detailed_description has described nothing,
+        # and the section is simply absent from the output rather than visibly empty.
+        if not description_words:
+            ref_warnings.append(
+                "detailed_description is empty; the guide lists it as a required field. "
+                "Write what happens in the global prompt box or on a timeline segment.")
+
+        # A voice-timbre reference for someone who never speaks. The guide's declaration
+        # "reuses the same (Sx) but never assigns a new one independently", so with no vocal
+        # event there is no ID to reuse and the sentence ends on the label — correct, and
+        # baffling if nothing says why.
+        for entry in ref_labels:
+            subject = entry.get("voice_of")
+            if not subject or subject in speaker_of_subject:
+                continue
+            ref_warnings.append(
+                "%s is the voice of <Subject %d>, who has no spoken line, so the guide's "
+                "speaker ID could not be reused in its definition. Write the line as "
+                "`@ref%s says: …` to give them one."
+                % (entry["label"], subject, slot_of_subject.get(subject, "N")))
     else:
         prompt = compile_storyboard(global_prompt, shots, window_seconds)
         if ref_notes:

--- a/test_plan.py
+++ b/test_plan.py
@@ -613,7 +613,8 @@ check("nothing written falls back to the generated sentence",
 # <d>[Language] ...</d>; and a cue inside reused audio names <Audio N> with no invented ID.
 prose, spoken = plan.split_dialogue(
     "she jerks her hand back\n@ref1 exclaims with light annoyance: Hey! Watch your dog!")
-check("dialogue is lifted out of the prose", prose, "she jerks her hand back")
+check("dialogue is lifted out of the prose, leaving a mark where it sat", prose,
+      "she jerks her hand back\n" + plan.DIALOGUE_MARK % 0)
 check("the tag, delivery and line are read apart",
       (spoken[0]["slot"], spoken[0]["delivery"], spoken[0]["line"]),
       (1, "exclaims with light annoyance", "Hey! Watch your dog!"))
@@ -666,6 +667,54 @@ check_in("a dialogue-only shot is still numbered and kept",
          "[Shot 2] At 00:05.000, <Subject 1> (S1) whispers, <d>[English] at last</d>",
          only_talk["prompt"])
 
+# A shot is not a paragraph followed by its dialogue. The guide's own Shot 1 goes action,
+# spoken line, more action, so a line written between two paragraphs has to stay between them.
+between = compile(tl([img(0, 288, "a.png",
+                          prompt="@ref1: before mid segment\n\nmid segment\n\n"
+                                 "@ref1: after mid segment")], ref_mode="ON",
+                     global_prompt="global prompt here",
+                     subjects=[{"images": [], "description": "a woman"}]))
+check_in("a spoken line stays where it was written",
+         "[Shot 1] a woman (S1) says, <d>[English] before mid segment</d> mid segment. "
+         "The shot begins from <Picture 1>. a woman (S1) says, "
+         "<d>[English] after mid segment</d>", between["prompt"])
+check("both lines belong to the one speaker",
+      len(set(re.findall(r"\(S\d+\)", between["prompt"]))), 1)
+
+# `</d>` is a closing tag, not the end of a sentence — the guide runs the next action straight
+# out of it. Everything else gets the full stop the next piece needs.
+check("nothing is invented after a spoken line",
+      plan.join_shot_pieces(["she waits", "<d>[English] hello</d>", "she turns away"]),
+      "she waits. <d>[English] hello</d> she turns away")
+check("a piece that already ends on punctuation is left alone",
+      plan.join_shot_pieces(["she waits,", "then turns"]), "she waits, then turns")
+check("empty pieces are dropped rather than punctuated",
+      plan.join_shot_pieces(["", "she waits", "   "]), "she waits")
+
+# Whichever comes first in the shot introduces the subject in full — the "called" name is for
+# every mention after that, and a spoken line is a mention like any other.
+first_seen = compile(tl([{"type": "text", "start": 0, "length": 288,
+                          "prompt": "@ref1: Morning.\n@ref1 wipes the counter"}],
+                        subjects=[{"images": [], "description": "a raspy-voiced baker",
+                                   "shortName": "the baker"}]))
+check_in("a subject introduced by its own spoken line is named in full there",
+         "[Shot 1] a raspy-voiced baker (S1) says, <d>[English] Morning.</d> the baker wipes "
+         "the counter", first_seen["prompt"])
+check_in("and prose that comes first still wins when it does",
+         "[Shot 1] a raspy-voiced baker wipes the counter. the baker (S1) says, "
+         "<d>[English] Morning.</d>",
+         compile(tl([{"type": "text", "start": 0, "length": 288,
+                      "prompt": "@ref1 wipes the counter\n@ref1: Morning."}],
+                    subjects=[{"images": [], "description": "a raspy-voiced baker",
+                               "shortName": "the baker"}]))["prompt"])
+
+check_in("the comfyui format keeps the written order too",
+         "she waits. <Picture 1> (S1) says, <d>[English] hello</d> she turns away",
+         compile(tl([img(0, 288, "a.png", prompt="she waits\n@ref1: hello\nshe turns away")],
+                    ref_mode="ON", prompt_format="comfyui",
+                    subjects=[{"images": [{"b64": "x", "name": "w.png"}],
+                               "description": "a woman"}]))["prompt"])
+
 # guide 5.4: verbal content inside reused audio has no independent vocal source
 bgm = compile(tl([img(0, 240, "a.png", prompt="@audio1: we'll meet again")], ref_mode="ON",
                  audioSegments=[{"audioFile": "song.wav", "start": 0, "length": 240,
@@ -691,6 +740,79 @@ check_in("a speaker ID in a retention note is reported",
                           )["ref_warnings"]))
 check("a clean timeline reports no speaker-ID warning",
       any("(Sx)" in w for w in talk["ref_warnings"]), False)
+
+# A line meant to be spoken that the dialogue rule did not claim. Reported, never repaired:
+# the colon is the rule, and taking quoted text would claim prose that quotes a thing.
+check("a quoted line with no colon is a near-miss",
+      plan.near_miss_dialogue('@ref1 says "hello sir"'),
+      [('@ref1 says "hello sir"', "colon")])
+check("...with the delivery and a language in front of it",
+      bool(plan.near_miss_dialogue('@ref1 [French] murmure "bonjour"')), True)
+check("...and a trailing full stop does not hide it",
+      bool(plan.near_miss_dialogue('@ref1 says "hello sir".')), True)
+check("@char takes a colon and still does not speak",
+      plan.near_miss_dialogue("@char1 says: hello sir"),
+      [("@char1 says: hello sir", "alias")])
+check("prose that quotes a thing and carries on is left alone",
+      plan.near_miss_dialogue('@ref1 reads the sign "Closed" and frowns'), [])
+check("so is a quote followed by more action",
+      plan.near_miss_dialogue('@ref1 says "hello" while @ref1 waves'), [])
+check("so is plain prose", plan.near_miss_dialogue("@ref1 walks to the counter"), [])
+check("so is real dialogue", plan.near_miss_dialogue("@ref1 says: hello sir"), [])
+check("a tag mid-line is not a near-miss either",
+      plan.near_miss_dialogue('she looks at @ref1 and says "hi"'), [])
+
+near = compile(tl([img(0, 144, "a.png", prompt="she waits"),
+                   img(144, 144, "b.png", prompt='@ref1 says "hello sir"')], ref_mode="ON",
+                  subjects=[{"images": [{"b64": "x", "name": "c.png"}],
+                             "description": "a woman"}]), duration_f=288)
+check_in("the near-miss names the shot it is in and the shape to write",
+         "[Shot 2] `@ref1 says \"hello sir\"` reads as dialogue but has no colon",
+         " ".join(near["ref_warnings"]))
+check_in("...and says what the line lost by staying prose",
+         "no speaker ID, no <d>[Language] …</d>", " ".join(near["ref_warnings"]))
+check_in("the line itself is untouched", '<Subject 1> says "hello sir"', near["prompt"])
+check("a timeline with real dialogue reports no near-miss",
+      any("reads as dialogue" in w for w in talk["ref_warnings"]), False)
+
+# detailed_description is a required core field in both guides, and unlike the soundscape it
+# has no N/A: the section is simply absent when nothing was written.
+check_in("an empty detailed_description is reported",
+         "detailed_description is empty; the guide lists it as a required field",
+         " ".join(compile(tl([], ref_mode="ON", global_prompt="",
+                             subjects=[{"images": [{"b64": "x", "name": "c.png"}],
+                                        "description": "a woman"}]))["ref_warnings"]))
+check("a timeline that says something is not nagged about it",
+      any("detailed_description is empty" in w for w in talk["ref_warnings"]), False)
+
+# The declaration "reuses the same (Sx) but never assigns a new one independently", so a
+# subject who never speaks leaves it with nothing to reuse — correct, and baffling unsaid.
+silent_voice = compile(tl([img(0, 288, "a.png", prompt="she waits")], ref_mode="ON",
+                          subjects=[{"images": [{"b64": "x", "name": "c.png"}],
+                                     "description": "a woman"}],
+                          audioSegments=[{"audioFile": "v.wav", "fileName": "v.wav",
+                                          "start": 0, "length": 288, "subject": 1}]),
+                       use_custom_audio=True)
+check_in("a voice reference for a subject who never speaks is reported",
+         "<Audio 1> is the voice of <Subject 1>, who has no spoken line, so the guide's "
+         "speaker ID could not be reused in its definition. Write the line as "
+         "`@ref1 says: …` to give them one.", " ".join(silent_voice["ref_warnings"]))
+check("...and once they speak, nothing is reported",
+      any("has no spoken line" in w for w in
+          compile(tl([img(0, 288, "a.png", prompt="@ref1 says: hello sir")], ref_mode="ON",
+                     subjects=[{"images": [{"b64": "x", "name": "c.png"}],
+                                "description": "a woman"}],
+                     audioSegments=[{"audioFile": "v.wav", "fileName": "v.wav",
+                                     "start": 0, "length": 288, "subject": 1}]),
+                  use_custom_audio=True)["ref_warnings"]), False)
+check("an unbound clip is nobody's voice, so there is nothing to report",
+      any("has no spoken line" in w for w in
+          compile(tl([img(0, 288, "a.png", prompt="she waits")], ref_mode="ON",
+                     subjects=[{"images": [{"b64": "x", "name": "c.png"}],
+                                "description": "a woman"}],
+                     audioSegments=[{"audioFile": "v.wav", "fileName": "v.wav",
+                                     "start": 0, "length": 288}]),
+                  use_custom_audio=True)["ref_warnings"]), False)
 # The word count is a figure in the preview badge, not a warning. The guide's 350-500 is a
 # lot for a 5-15s clip, so being under it is the ordinary state here — warning about it
 # fired on essentially every timeline, which is how a warnings area stops being read.
@@ -1035,9 +1157,8 @@ bound = compile(tl([img(0, 288, "a.png", prompt="they talk")], ref_mode="ON",
                 use_custom_audio=True)
 check_in("a clip tied to a subject uses the guide's own sentence",
          "<Audio 1> is the voice-timbre reference for <Subject 2>.", bound["prompt"])
-# the ID is not knowable at declaration time — speakers are numbered in vocal-event order,
-# and this subject may never speak — so the label carries the binding on its own
-check_not_in("no speaker ID is invented for it", "(S", bound["prompt"])
+# a subject who never speaks has no ID to reuse, so the label carries the binding on its own
+check_not_in("a silent subject gets no speaker ID", "(S", bound["prompt"])
 check_in("and the retention line says whose voice it is",
          "<Audio 1> (voice of <Subject 2>): reference - ", bound["prompt"])
 
@@ -1082,6 +1203,62 @@ check("a clip pointing at a slot with no images binds nothing",
       compile(tl([img(0, 288, "a.png", prompt="x")], ref_mode="ON",
                  characters=two_chars, audioSegments=[audio(subject=3)]),
               use_custom_audio=True)["prompt"], False)
+
+# ------------------------------ the declaration reuses the speaker's global ID
+# "When an <Audio N> explicitly corresponds to a target speaker, reuse that speaker's global
+# ID in the definition." The ID is the speaking order, not the subject number — subject 1
+# speaks first here, so the clip bound to subject 2 ends up (S2), which is the guide's own
+# <Subject 3> (S1) case seen from the other side.
+speaks = tl([img(0, 144, "a.png", prompt="@ref1 says: you first"),
+             img(144, 144, "b.png", prompt="@ref2 says: after you")], ref_mode="ON",
+            characters=two_chars, audioSegments=[audio(subject=2)])
+voiced = compile(speaks, use_custom_audio=True)
+check_in("a bound clip ends on the speaker's global ID",
+         "<Audio 1> is the voice-timbre reference for <Subject 2> (S2).", voiced["prompt"])
+check_in("and the same ID is on the spoken line",
+         "<Subject 2> (S2) says, <d>[English] after you</d>", voiced["prompt"])
+check_not_in("the ID still stays out of retention_analysis", "(S",
+             voiced["prompt"].split("retention_analysis:")[1]
+                             .split("detailed_description")[0])
+
+check_in("a copied clip names the ID too",
+         "<Audio 1> carries the voice of <Subject 2> (S2): its signal is reused in the "
+         "target video.",
+         compile(tl([img(0, 144, "a.png", prompt="@ref1 says: you first"),
+                     img(144, 144, "b.png", prompt="@ref2 says: after you")], ref_mode="ON",
+                    characters=two_chars,
+                    audioSegments=[dict(audio(subject=2), retention="fully_copy")]),
+                 use_custom_audio=True)["prompt"])
+
+check_in("a hand-written declaration that names the subject gains the ID",
+         "<Audio 1> is the gravel in the voice of <Subject 2> (S2).",
+         compile(tl([img(0, 144, "a.png", prompt="@ref1 says: you first"),
+                     img(144, 144, "b.png", prompt="@ref2 says: after you")], ref_mode="ON",
+                    characters=two_chars,
+                    audioSegments=[dict(audio(subject=2),
+                                        refDesc="the gravel in the voice of <Subject 2>")]),
+                 use_custom_audio=True)["prompt"])
+check_in("one that writes its own ID is left exactly as typed",
+         "<Audio 1> is the voice-timbre reference for <Subject 2> (S2).",
+         compile(tl([img(0, 144, "a.png", prompt="@ref1 says: you first"),
+                     img(144, 144, "b.png", prompt="@ref2 says: after you")], ref_mode="ON",
+                    characters=two_chars,
+                    audioSegments=[dict(audio(subject=2),
+                                        refDesc="the voice-timbre reference for "
+                                                "<Subject 2> (S2)")]),
+                 use_custom_audio=True)["prompt"])
+check_in("one that names somebody else keeps the ID off it entirely",
+         "<Audio 1> is the room the voices were recorded in.",
+         compile(tl([img(0, 144, "a.png", prompt="@ref1 says: you first")], ref_mode="ON",
+                    characters=two_chars,
+                    audioSegments=[dict(audio(subject=1),
+                                        refDesc="the room the voices were recorded in")]),
+                 use_custom_audio=True)["prompt"])
+check_in("a silent subject is not numbered just because somebody else spoke",
+         "<Audio 1> is the voice-timbre reference for <Subject 2>.\n",
+         compile(tl([img(0, 288, "a.png", prompt="@ref1 says: only me")], ref_mode="ON",
+                    characters=two_chars, audioSegments=[audio(subject=2)]),
+                 use_custom_audio=True)["prompt"])
 
 # ------------------------------------------- a hand-written prompt replaces the text
 base_tl = tl([img(0, 144, "a.png", prompt="she enters"),


### PR DESCRIPTION
Closes #19 

- an `<Audio N>` bound to a subject ends its declaration on that speaker's
  global ID, which the guide reuses and never assigns independently
- a spoken line stays where it was written instead of being appended to
  the end of its shot, so first-appearance and (Sx) follow one order
- warn on a near-miss dialogue line, an empty detailed_description, and a
  voice reference whose subject never speaks

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
