### PR TITLE
fix(director): let a reference clip live outside the render window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,17 @@
   was never handed. The log now names the clip, its label, and — for a file that is not in
   the input folder, or a trim that starts past the end of the audio — what went wrong.
 
+- **Override Audio wins over the audio track outside the editor too.** The two are answers to
+  one question, and the editor has always kept them exclusive: turning either on turns the
+  other off. Nothing enforced that on the Python side, so a hand-edited or scripted workflow
+  could arrive with both — and then every audio label in the prompt was wrong, because a
+  reference video's soundtrack is numbered `<Audio 1>` before any clip on the track is
+  reached. A voice binding written for a clip named a soundtrack instead. Override Audio now
+  wins there as well, and the clips it set aside are named in the warnings area. Renumbering
+  around it is not possible from where the prompt is written: a reference video with no audio
+  stream contributes no `<Audio>` label at all, and that is not knowable until the file is
+  opened.
+
 ## 0.2.2
 
 Two contributions from [@Brioch](https://github.com/Brioch) — [#16] and [#17], closing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## Unreleased
+
+- **A reference no longer spends output time.** A reference is an input to the
+  model, not content in the video — `<Video k>` and `<Audio j>` are never composited — but a
+  clip had to overlap the render window to be sent at all, and dropping one stretched the
+  window to cover it. The model card wants each reference audio clip 10–15 s long, so three
+  of them grew the output to 45 s: three times the longest video H3 can make. Shortening it
+  back to something renderable then dropped the second and third clip in silence. Three
+  references and a renderable length were mutually exclusive.
+
+  Neither reference track touches the output length now, and a clip is sent from wherever it
+  sits. Dropped clips land after the last one, which for anything longer than the window
+  means out in the shaded area past it — where the canvas has always said "not in the video",
+  and where a reference belongs. A 5 s render sends all three.
+
+  Position still decides one thing, and only for audio: whether the clip is **also** part of
+  the muxed soundtrack. Inside the window it is both; past it, it is a reference and nothing
+  else, which the clip's info panel says when you select it rather than leaving it to be read
+  off a shaded background. Not the warnings area — parking is the ordinary case now, and a
+  line that fires on every timeline of a kind is how a warnings area stops being read.
+  **Override Audio** is the exception that does warn, because there two explicit choices
+  contradict each other: it takes the soundtrack from the reference videos, and a parked clip
+  has none to give. Everything else about a clip — **Voice of**, **describes**, **retained**,
+  its marker — is unchanged by where it sits, so a timeline whose clips all sat inside the
+  window compiles exactly as it did.
+
+  A retake keeps the old rule: there the window is a deliberate slice of a video that already
+  exists, so outside the marked range means another part of that same video, not parked.
+
+  Two consequences worth naming. A parked reference video is sent whole on its own trim
+  instead of having the window's start subtracted off its head, which was arithmetic about a
+  window the clip has nothing to do with. And both per-type caps — 3 audio, 3 video — used to
+  trim in silence; they now name the clip they dropped, like every other reference limit
+  already did. Parking is what made that worth fixing: a fourth clip out in the shade looks
+  exactly as loaded as the three being sent.
+
 ## 0.2.1
 
 Four reports, and one of them was right about something this pack had been saying wrongly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,25 @@
   already did. Parking is what made that worth fixing: a fourth clip out in the shade looks
   exactly as loaded as the three being sent.
 
+- **Every audio clip on the track plays its own file again.** With two clips loaded, both
+  showed up in the prompt and both drew their own waveform, but only one of them could be
+  heard — the other played as the first, which reads as there being room for a single audio
+  file. The preview was the whole of it. After decoding a clip, the editor handed the
+  finished buffer to every clip that matched it, and a standalone audio clip has no blob URL
+  to be matched on — a saved timeline has none at all, since the key is stripped on the way
+  out. So the test was `undefined === undefined`, true for the whole track, and whichever
+  clip decoded last became what the play button played everywhere. What is sent to the model
+  was never affected: three clips have always been three `<Audio N>` references.
+
+- **A reference clip that cannot be read says which one it was.** Both reference tracks
+  dropped a clip they could not load without a word — a missing audio file did not even
+  reach the log, because resolving a path that is not there returns nothing to report. That
+  is the one drop that must be loud. The prompt is compiled before any file is opened and it
+  numbers `<Audio N>` and `<Video k>` by the clip's place on the track, so a clip lost here
+  does not simply go missing: that label and every one after it names a reference the model
+  was never handed. The log now names the clip, its label, and — for a file that is not in
+  the input folder, or a trim that starts past the end of the audio — what went wrong.
+
 ## 0.2.2
 
 Two contributions from [@Brioch](https://github.com/Brioch) — [#16] and [#17], closing

--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ see the exact prompt the model will receive while you are still editing it.
 
 ## News
 
+**Unreleased** — a **reference clip no longer has to fit inside the render window**. Neither
+reference track stretches the output any more, so three 10–15 s audio references park past
+the end and a 5 s render still sends all three. Position decides one thing only: whether an
+audio clip is also part of the muxed soundtrack.
+
 **0.2.1** · 2026-08-16 — **width and height can be wired in** from a resolution node, as
 connection-only inputs beside `start` / `end` / `duration`. The **Analyze** button can now
 reach a cloud endpoint: there is an API-key field, kept in ComfyUI's settings and never in
@@ -264,6 +269,32 @@ readable; open them if you want to change sampler, scheduler or steps.
 | **Audio** | music, SFX | `<Audio j>` reference and/or the muxed soundtrack |
 | **Subject slots** | images | `<Subject N>` definitions — people, scenes, props, styles |
 
+### References do not spend output time
+
+A reference is an **input** to the model, not content in the video: `<Video k>` and
+`<Audio j>` are never composited. So neither one has to fit inside the render window, and
+dropping either never stretches the output — only the main track decides how long the video
+is. A clip dropped on one of those two tracks lands after the last one, which for anything
+longer than the window means out in the **shaded area past it**, and it is sent from there.
+
+That is the only way the model card's own numbers work out. It wants each reference audio
+clip 10–15 s long, so three of them need 45 s of track — three times the longest video H3
+can make. Park them and a 5 s render still sends all three.
+
+What the window decides is one thing: whether an audio clip is **also** part of the muxed
+soundtrack. Inside it, a clip is both a reference and sound in the video. Past it, it is a
+reference and nothing else, which the clip's **info panel says when you select it** — not the
+warnings area, because parking is the ordinary case and a warning that fires every time stops
+being read. Drag the clip back in and it joins `combined_audio` again.
+
+**Override Audio** is the one case that does warn, because it is the one place two explicit
+choices contradict each other: it takes the soundtrack from the reference videos, and a parked
+clip has none to give. That earns a line naming the clips it cannot use.
+
+A **retake** keeps the old rule, where the window is a deliberate slice of a video that
+already exists. Outside the marked range there means *another part of that same video*, not
+parked, so a clip out there is not a reference either.
+
 ### Driving it from other nodes
 
 The settings panel owns the canvas and the window, and hides the widgets behind them so
@@ -295,7 +326,7 @@ These are enforced, with a warning naming exactly what was dropped:
 |---|---|
 | Reference images | ≤ 9 — the subject slots *and* the `ref_images` input share this pool |
 | Reference videos | ≤ 3 clips, each 2–15 s, **≤ 15 s total** |
-| Reference audio | ≤ 3 clips |
+| Reference audio | ≤ 3 clips, 10–15 s each is what the card asks for |
 | **All types together** | **≤ 12 files** |
 
 Output envelope: 4–15 s at 24 fps — the range H3 was trained on, and **not** a limit this
@@ -535,6 +566,11 @@ reference for <Subject 1>.` Leave it unset and the clip stays a general voice re
 before. The guide's own example ends that sentence with a speaker ID, `(S1)`; this does not,
 because IDs are handed out in the order voices are actually heard and a subject with a voice
 reference need never speak. Where the subject does speak, the ID is on the line itself.
+
+None of that depends on where the clip sits. A clip parked past the render window carries its
+**Voice of** binding, its **describes** line and its marker exactly as one inside it does —
+[a reference does not spend output time](#references-do-not-spend-output-time). Position
+decides the soundtrack and nothing else.
 
 **Analyze** is optional and off the critical path. It sends the slot image to a vision
 model and pastes back a one-line description, so `@ref1` still means something in

--- a/README.md
+++ b/README.md
@@ -302,6 +302,13 @@ being read. Drag the clip back in and it joins `combined_audio` again.
 choices contradict each other: it takes the soundtrack from the reference videos, and a parked
 clip has none to give. That earns a line naming the clips it cannot use.
 
+Override Audio also *replaces* the audio track rather than joining it, which is why the editor
+turns one off when you turn the other on. A workflow can still arrive with both on —
+hand-edited, or driven from another node — and there Override Audio wins and the track's clips
+are not sent: `<Audio j>` numbers each reference video's soundtrack before it reaches a
+standalone clip, so sending both would leave every clip in the prompt labelled as one the model
+was never given. The warnings area names what was left out.
+
 A **retake** keeps the old rule, where the window is a deliberate slice of a video that
 already exists. Outside the marked range there means *another part of that same video*, not
 parked, so a clip out there is not a reference either.

--- a/js/minimax_director.js
+++ b/js/minimax_director.js
@@ -291,6 +291,9 @@ const STYLES = `
   .mmxd-audio-subject-label { display: inline-flex; align-items: center; gap: 6px; margin-top: 6px; color: #aaa; }
   .mmxd-audio-subject { background: #2a2a2a; color: #e6e6e6; border: 1px solid #444; border-radius: 4px; height: 22px; padding: 0 4px; font-size: 11px; font-family: inherit; cursor: pointer; outline: none; max-width: 260px; }
   .mmxd-audio-subject:hover { background: #343434; border-color: #666; }
+  /* a clip parked past the render window: still a reference, so this states a fact rather
+     than warning about one — the amber the prompt panel uses for problems would overstate it */
+  .mmxd-ref-only { margin-top: 6px; color: #8fb8d8; font-style: italic; }
   .mmxd-controls-group {
     background: #1e1e1e;
     border: 1px solid #333;
@@ -1704,6 +1707,12 @@ class TimelineEditor {
 
   // Grow the timeline duration to fit `requiredFrames` if it is currently shorter.
   // The timeline only ever grows — never shrinks — through this method.
+  // Only the main track calls this, and that is the rule rather than an accident: a
+  // reference is an input to the model, not content in the video, so an <Audio N> or
+  // <Video N> clip must never stretch the output. Reference audio wants to be 10-15s per
+  // the model card, and three of those growing the window would ask H3 for 45s of video —
+  // past anything it can render. Keyframes and prompt zones decide the length;
+  // references park in the shaded area past it and are sent from there.
   growTimelineIfNeeded(requiredFrames) {
     const current = this.getDurationFrames();
     if (requiredFrames <= current) return; // already big enough
@@ -5193,9 +5202,8 @@ class TimelineEditor {
     this.timeline.motionSegments.push(seg);
     this.timeline.motionSegments.sort((a, b) => a.start - b.start);
 
-    if (!this.retakeMode) {
-      this.growTimelineIfNeeded(seg.start + seg.length);
-    }
+    // deliberately no growTimelineIfNeeded: a <Video N> reference is not in the video, so
+    // it does not decide how long the video is — see the note on that method
 
     this.selectionType = "motion";
     this.selectedIndex = this.timeline.motionSegments.findIndex(s => s.id === seg.id);
@@ -5430,9 +5438,10 @@ class TimelineEditor {
           this.timeline.audioSegments.push(seg);
           this.timeline.audioSegments.sort((a, b) => a.start - b.start);
 
-          if (!this.retakeMode) {
-            this.growTimelineIfNeeded(seg.start + seg.length);
-          }
+          // deliberately no growTimelineIfNeeded: the clip lands after the last one, which
+          // for anything longer than the window means out in the shaded area — where it is
+          // an <Audio N> reference and not part of the soundtrack. Stretching the output to
+          // cover it is what made a second and third reference clip unreachable.
 
           this.selectionType = "audio";
           this.selectedIndex = this.timeline.audioSegments.findIndex(s => s.id === seg.id);
@@ -5733,7 +5742,12 @@ class TimelineEditor {
     this.selectionType = copiedTrack;
     this.selectedIndex = this.getSegmentArray(copiedTrack).findIndex(s => s.id === mainSeg.id);
 
-    if (!this.retakeMode) {
+    // Only a paste that put something on the main track can decide the output length —
+    // exactly the three cases the assignment above writes `this.timeline.segments` in. A
+    // lone audio or reference-video clip is a reference and grows nothing; an audio clip
+    // with a `_v` sibling means a real video landed on the main track, which does.
+    const onMainTrack = copiedTrack === "audio" ? !!sibSeg : copiedTrack !== "motion";
+    if (!this.retakeMode && onMainTrack) {
       this.growTimelineIfNeeded(mainSeg.start + mainSeg.length);
     }
 
@@ -6108,6 +6122,9 @@ class TimelineEditor {
     const parts = [`${secs.toFixed(1)}s`];
     if (secs < 2) parts.push("under the 2s minimum");
     else if (secs > 15) parts.push("over the 15s maximum");
+    // Where it sits, when that is past the window: still sent, and not in the video. The
+    // shaded background says only the second half of that.
+    if (this._refOnlyNote(seg, "motion")) parts.push("past the window, sent as a reference");
     this.refLimitsNote.textContent = parts.join(" · ");
     this.refLimitsNote.style.color = (secs < 2 || secs > 15) ? "#d08a3a" : "#5a5a5a";
   }
@@ -6125,6 +6142,23 @@ class TimelineEditor {
       this.node.setSize([this.node.size[0], this.node.computeSize()[1]]);
       this.node.setDirtyCanvas(true, true);
     }
+  }
+
+  // What to say about a reference clip parked outside the render window. It is still sent
+  // to the model — that is the whole point of parking it there — and the shaded
+  // background only says "not in the video", which is the half that misleads. Empty for a
+  // clip that reaches into the window, in retake mode, and with refs off, where nothing is
+  // sent from either side of the line.
+  _refOnlyNote(seg, kind) {
+    if (!seg || this.retakeMode) return "";
+    if (String(this.timeline.reference_mode || "OFF").toUpperCase() === "OFF") return "";
+    const winStart = this.getStartFrames();
+    const winEnd = winStart + this.getDurationFrames();
+    const start = seg.start || 0;
+    if (start < winEnd && start + (seg.length || 0) > winStart) return "";
+    return kind === "audio"
+      ? "Past the render window: sent as a reference, and no part of the soundtrack."
+      : "Past the render window: sent as a reference.";
   }
 
   // Shows the describes/retained strip for whichever reference is selected, and fills it.
@@ -6314,6 +6348,7 @@ class TimelineEditor {
       // somewhere to say it, a second voice reference is just another numbered clip with
       // no way to tell the model who is speaking (issue #10).
       const options = this._audioSubjectOptions(seg);
+      const parkedNote = this._refOnlyNote(seg, "audio");
       this.audioInfoArea.innerHTML = `
         File: <span>${escapeAttr(seg.fileName || "Unknown")}</span><br>
         Length: <span>${this.formatTime(seg.audioDurationFrames)}</span> Output Length: <span>${this.formatTime(seg.length)}</span><br>
@@ -6321,6 +6356,7 @@ class TimelineEditor {
         <label class="mmxd-audio-subject-label">Voice of:
           <select class="mmxd-audio-subject">${options}</select>
         </label>
+        ${parkedNote ? `<div class="mmxd-ref-only">${parkedNote}</div>` : ""}
       `;
       const subjSel = this.audioInfoArea.querySelector(".mmxd-audio-subject");
       if (subjSel) {

--- a/js/minimax_director.js
+++ b/js/minimax_director.js
@@ -2392,7 +2392,16 @@ class TimelineEditor {
         }
       }
 
-      const matchingSegs = this.timeline.audioSegments.filter(s => s.audioFile === seg.audioFile || s._blobUrl === seg._blobUrl);
+      // Only the clips that really are this file. A standalone audio clip never gets a
+      // `_blobUrl`, and commitChanges strips the key from every segment it saves, so
+      // `s._blobUrl === seg._blobUrl` read `undefined === undefined` for the whole track:
+      // on a reloaded workflow one clip's buffer was stamped over every other clip, and
+      // the play button played that one file at every clip's position. The waveforms
+      // stayed right, which is what made it look like a limit on how many audio files fit
+      // rather than a mix-up. `_extractAudioOnClient` guards the same loop.
+      const matchingSegs = this.timeline.audioSegments.filter(
+        s => (seg.audioFile && s.audioFile === seg.audioFile) ||
+             (seg._blobUrl && s._blobUrl === seg._blobUrl));
       for (const s of matchingSegs) {
         s._audioBuffer = audioBuffer;
         s._decoding = false;

--- a/minimax_director.py
+++ b/minimax_director.py
@@ -559,7 +559,7 @@ class MiniMaxH3Director(io.ComfyNode):
         if p["ref_mode_on"]:
             ref_image_tensors = load_ref_image_tensors(p["ref_image_slots"], fit, ref_images)
 
-            for seg in p["ref_video_segs"]:
+            for i, seg in enumerate(p["ref_video_segs"]):
                 idx = len(ref_videos)
                 seg_start = float(seg.get("start", 0))
                 seg_len = float(seg.get("length", 1))
@@ -589,7 +589,10 @@ class MiniMaxH3Director(io.ComfyNode):
                     max_pixels=int(short_edge * short_edge * plan.REF_VIDEO_ASPECT_BUDGET))
                 if frames.shape[0] < 5:
                     log.warning("[MiniMaxDirector] Reference video '%s' is shorter than 5 "
-                                "frames — skipped.", seg.get("fileName", seg["videoFile"]))
+                                "frames — skipped. The prompt still declares it as "
+                                "<Video %d>, so that label and every one after it now name "
+                                "a clip the model was not given.",
+                                plan.seg_name(seg), i + 1)
                     continue
                 ref_videos["ref_video_%d" % idx] = frames
                 if override_audio:
@@ -599,10 +602,20 @@ class MiniMaxH3Director(io.ComfyNode):
                     if clip_audio is not None:
                         ref_video_audios["ref_video_audio_%d" % idx] = clip_audio
 
-            for seg in p["ref_audio_segs"]:
+            for i, seg in enumerate(p["ref_audio_segs"]):
                 clip_audio = media.load_audio_segment(seg, fps)
-                if clip_audio is not None:
-                    ref_audios["ref_audio_%d" % len(ref_audios)] = clip_audio
+                if clip_audio is None:
+                    # The prompt is already written, and it numbers <Audio N> by the clip's
+                    # place on the track. Dropping one in silence therefore does not just
+                    # lose a reference: every label from here on names a different clip
+                    # than the model was handed. load_audio_segment has already said why
+                    # this one could not be read.
+                    log.warning("[MiniMaxDirector] Reference audio '%s' could not be "
+                                "loaded — the prompt still declares it as <Audio %d>, so "
+                                "that label and every one after it now name a clip the "
+                                "model was not given.", plan.seg_name(seg), i + 1)
+                    continue
+                ref_audios["ref_audio_%d" % len(ref_audios)] = clip_audio
 
             if first_frame is not None or last_frame is not None:
                 log.info("[MiniMaxDirector] ref2va has no first/last keyframe slot — the "

--- a/minimax_director.py
+++ b/minimax_director.py
@@ -563,7 +563,13 @@ class MiniMaxH3Director(io.ComfyNode):
                 idx = len(ref_videos)
                 seg_start = float(seg.get("start", 0))
                 seg_len = float(seg.get("length", 1))
-                offset = max(0.0, win_start - seg_start)
+                # Only a clip that reaches into the window has a head the window cuts off.
+                # A clip parked outside it goes whole, on its own trim: the window start is
+                # then nothing to do with the clip, and subtracting it would eat the front
+                # of a reference for a reason that has no bearing on it.
+                offset = (max(0.0, win_start - seg_start)
+                          if plan.overlaps(seg, win_start, win_start + duration_frames)
+                          else 0.0)
                 trim = float(seg.get("trimStart", 0)) + offset
                 # The segment's own length is the answer, capped only at the model card's
                 # ceiling. It used to be floored at 2s as well, which meant trimming a clip

--- a/minimax_media.py
+++ b/minimax_media.py
@@ -1085,7 +1085,16 @@ def build_combined_audio(timeline_data_str: str, start_frame: int, duration_fram
     out = torch.zeros((2, total_samples), dtype=torch.float32)
     file_key = "videoFile" if override_audio else "audioFile"
 
+    # the planner's own test, not a second copy of it — where the window is concerned the
+    # mixdown and the plan have to agree
+    from . import minimax_plan as plan
+
     for seg in audio_segs:
+        # A clip that cannot reach the window contributes nothing, and reference clips are
+        # routinely parked outside it now — so decide that before reading a file
+        # off disk and decoding 15s of it to add zero samples.
+        if not plan.overlaps(seg, start_frame, start_frame + duration_frames):
+            continue
         buffer = None
         if seg.get(file_key):
             path = resolve_input_path(seg[file_key])

--- a/minimax_media.py
+++ b/minimax_media.py
@@ -949,6 +949,15 @@ def load_audio_segment(seg: dict, frame_rate: float, file_key: str = "audioFile"
                 waveform = _decode_audio_stereo(path)
             except Exception as e:
                 log.warning("[MiniMaxDirector] Audio decode failed for %s: %s", seg.get(file_key), e)
+        elif not seg.get("audioB64"):
+            # A clip whose file has gone is the one failure that used to leave nothing at
+            # all behind: the caller drops it, and with the prompt already written the
+            # <Audio N> labels then name references the model never got.
+            log.warning(
+                "[MiniMaxDirector] Audio clip '%s' is not in ComfyUI's input folder "
+                "(looked in it, in input/%s, and for the bare filename). The clip is on "
+                "the timeline but there is no file left to send — re-add it.",
+                seg[file_key], WORKSPACE_SUBDIR)
     if waveform is None and seg.get("audioB64"):
         try:
             b64 = seg["audioB64"]
@@ -964,6 +973,14 @@ def load_audio_segment(seg: dict, frame_rate: float, file_key: str = "audioFile"
     length = int(float(seg.get("length", 1)) / frame_rate * AUDIO_SR)
     clip = waveform[:, max(0, start):max(0, start) + max(1, length)]
     if clip.shape[1] <= 0:
+        # Not a missing file but timeline arithmetic: the trim starts past the end of the
+        # decoded audio. Say which clip and with what numbers, or it looks identical to a
+        # clip that was never loaded at all.
+        log.warning(
+            "[MiniMaxDirector] Audio clip '%s' came out empty: its trim starts at "
+            "%.2fs and the file decoded to %.2fs. Nothing to send — retrim the clip.",
+            seg.get("fileName") or seg.get(file_key),
+            float(seg.get("trimStart", 0)) / frame_rate, waveform.shape[1] / AUDIO_SR)
         return None
     return {"waveform": clip.unsqueeze(0), "sample_rate": AUDIO_SR}
 

--- a/minimax_plan.py
+++ b/minimax_plan.py
@@ -201,6 +201,13 @@ def overlaps(seg, win_start, win_end):
     return start < win_end and start + length > win_start
 
 
+def seg_name(seg):
+    """What to call a segment in a warning — the display name, or the file it came from."""
+    seg = seg or {}
+    return (seg.get("fileName") or seg.get("videoFile") or seg.get("audioFile")
+            or "an unnamed clip")
+
+
 def parse_timeline(timeline_data):
     try:
         return json.loads(timeline_data) if timeline_data else {}
@@ -1172,19 +1179,35 @@ def plan_timeline(tdata, win_start, duration_frames, fps, global_prompt="",
                     char_tag_later[slot_idx + 1] = slot["short_name"]
 
     # --- reference video / audio tracks ---
+    # A reference is an input to the model, not content in the video: <Video N> and
+    # <Audio N> are never composited, so neither has any business occupying output time.
+    # The model card wants each reference audio clip 10-15s long, and three of those would
+    # need a 45s timeline — longer than anything H3 can render. So where a clip
+    # sits does not decide whether it is a reference. It decides one thing only: whether an
+    # audio clip is *also* part of the muxed soundtrack, which build_combined_audio answers
+    # by filling the window and nothing else. A clip parked in the shaded area past the
+    # window is a reference and no more than that.
+    #
+    # Retake is the exception, and stays on the old rule. There the window is a deliberate
+    # sub-range of a video that already exists, so outside it means "another part of this
+    # same video" rather than "parked" — and the editor does not even draw the audio track.
     ref_video_segs, ref_audio_segs = [], []
+    over_cap = []
     if ref_mode_on:
         if use_custom_motion:
             motion = [s for s in (tdata.get("motionSegments", []) or [])
-                      if s.get("videoFile") and overlaps(s, win_start, win_end)]
+                      if s.get("videoFile")
+                      and (not retake or overlaps(s, win_start, win_end))]
             motion.sort(key=lambda s: float(s.get("start", 0)))
             ref_video_segs = motion[:MAX_REF_VIDEOS]
+            over_cap.extend(("video", MAX_REF_VIDEOS, s) for s in motion[MAX_REF_VIDEOS:])
         if use_custom_audio:
             audio = [s for s in (tdata.get("audioSegments", []) or [])
                      if (s.get("audioFile") or s.get("audioB64"))
-                     and overlaps(s, win_start, win_end)]
+                     and (not retake or overlaps(s, win_start, win_end))]
             audio.sort(key=lambda s: float(s.get("start", 0)))
             ref_audio_segs = audio[:MAX_REF_AUDIOS]
+            over_cap.extend(("audio", MAX_REF_AUDIOS, s) for s in audio[MAX_REF_AUDIOS:])
 
     # --- total file cap ---
     # The per-type caps are not the whole story: H3 also takes at most 12 reference files
@@ -1222,18 +1245,42 @@ def plan_timeline(tdata, win_start, duration_frames, fps, global_prompt="",
             if seconds < REF_VIDEO_MIN_SEC:
                 ref_warnings.append(
                     "Reference video '%s' is %.1fs; H3 wants 2-15s per clip."
-                    % (seg.get("fileName") or seg.get("videoFile"), seconds))
+                    % (seg_name(seg), seconds))
             # what this clip would actually contribute, after the per-clip cap
             usable = min(seconds, REF_VIDEO_MAX_SEC)
             # the question is whether it FITS, not whether anything is left at all
             if usable > budget + 1e-6:
                 ref_warnings.append(
                     "Reference videos exceed the %.0fs total budget; '%s' was dropped."
-                    % (REF_VIDEO_TOTAL_SEC, seg.get("fileName") or seg.get("videoFile")))
+                    % (REF_VIDEO_TOTAL_SEC, seg_name(seg)))
                 continue
             kept.append(seg)
             budget -= usable
         ref_video_segs = kept
+
+    # Both per-type caps used to trim in silence, which is the one thing a reference limit is
+    # not allowed to do — every other one names what it dropped. Parking clips off the window
+    # is what makes this worth saying: a fourth clip out in the shade looks exactly as loaded
+    # as the three that are being sent.
+    for kind, cap, seg in over_cap:
+        ref_warnings.append("H3 takes at most %d reference %s clips; '%s' was dropped."
+                            % (cap, kind, seg_name(seg)))
+
+    # Parked audio gets no warning: being a reference and not a soundtrack is the whole point
+    # of parking it, the clip's own info panel says which it is, and a line that fires on
+    # every timeline of a kind is how a warnings area stops being read.
+    #
+    # Override Audio is different, because it is the one place two explicit choices
+    # contradict each other. It says "take the soundtrack from the reference videos", and a
+    # parked clip cannot supply one — build_combined_audio fills the window and no more.
+    if override_audio:
+        muted = [seg_name(s) for s in ref_video_segs
+                 if not overlaps(s, win_start, win_end)]
+        if muted:
+            ref_warnings.append(
+                "Override Audio takes the soundtrack from the reference videos, and these "
+                "sit past the render window, so no part of them reaches combined_audio: %s."
+                % ", ".join("'%s'" % n for n in muted))
 
     # --- output length ---
     # Computed before the prompt because the alignment instruction has to name the

--- a/minimax_plan.py
+++ b/minimax_plan.py
@@ -1316,6 +1316,7 @@ def plan_timeline(tdata, win_start, duration_frames, fps, global_prompt="",
     # same video" rather than "parked" — and the editor does not even draw the audio track.
     ref_video_segs, ref_audio_segs = [], []
     over_cap = []
+    override_dropped_audio = []
     if ref_mode_on:
         if use_custom_motion:
             motion = [s for s in (tdata.get("motionSegments", []) or [])
@@ -1329,8 +1330,23 @@ def plan_timeline(tdata, win_start, duration_frames, fps, global_prompt="",
                      if (s.get("audioFile") or s.get("audioB64"))
                      and (not retake or overlaps(s, win_start, win_end))]
             audio.sort(key=lambda s: float(s.get("start", 0)))
-            ref_audio_segs = audio[:MAX_REF_AUDIOS]
-            over_cap.extend(("audio", MAX_REF_AUDIOS, s) for s in audio[MAX_REF_AUDIOS:])
+            # Override Audio and the audio track are two answers to one question — where the
+            # sound comes from — and the editor keeps them exclusive: turning either on turns
+            # the other off. Only a hand-edited or scripted workflow arrives with both, and
+            # both cannot be sent. Core emits an <Audio j> for each reference video's
+            # soundtrack *before* the standalone clips, while the labels here are numbered
+            # from the track alone, so every <Audio N> in the prompt would name a different
+            # clip than the model was handed and a voice binding would point at a soundtrack.
+            # Renumbering cannot fix it from here either: a reference video with no audio
+            # stream contributes no <Audio> item, which is not knowable until the file is
+            # opened. So Override Audio wins, exactly as it does in the editor — and where
+            # the mixdown is concerned it already had, since build_combined_audio reads the
+            # reference videos and never looks at the audio track on this path.
+            if override_audio and ref_video_segs:
+                override_dropped_audio = [seg_name(s) for s in audio]
+            else:
+                ref_audio_segs = audio[:MAX_REF_AUDIOS]
+                over_cap.extend(("audio", MAX_REF_AUDIOS, s) for s in audio[MAX_REF_AUDIOS:])
 
     # --- total file cap ---
     # The per-type caps are not the whole story: H3 also takes at most 12 reference files
@@ -1396,6 +1412,14 @@ def plan_timeline(tdata, win_start, duration_frames, fps, global_prompt="",
     # Override Audio is different, because it is the one place two explicit choices
     # contradict each other. It says "take the soundtrack from the reference videos", and a
     # parked clip cannot supply one — build_combined_audio fills the window and no more.
+    if override_dropped_audio:
+        ref_warnings.append(
+            "Override Audio and the audio track are two answers to one question, and the "
+            "editor keeps them exclusive; this timeline has both on. Override Audio wins "
+            "and these clips were not sent, because <Audio N> counts each reference video's "
+            "soundtrack first and every label in the prompt would have named a different "
+            "clip: %s." % ", ".join("'%s'" % n for n in override_dropped_audio))
+
     if override_audio:
         muted = [seg_name(s) for s in ref_video_segs
                  if not overlaps(s, win_start, win_end)]

--- a/test_plan.py
+++ b/test_plan.py
@@ -1185,6 +1185,29 @@ check("...and says nothing when every clip is inside the window",
                      motionSegments=[vid(0, 0, 96)]),
                   duration_f=120, override_audio=True)["ref_warnings"]), False)
 
+# Override Audio and the audio track cannot both be honoured. Core emits an <Audio j> for
+# each reference video's soundtrack before it reaches the standalone clips, and the labels
+# here are numbered from the track alone — so a clip on the track would be declared as a
+# soundtrack, and a voice binding would name one. The editor keeps the two exclusive; a
+# hand-edited or scripted workflow can still arrive with both, and then Override Audio wins,
+# exactly as it does there.
+both_on = compile(tl([img(0, 120, "a.png", prompt="she walks")], ref_mode="ON",
+                     motionSegments=[vid(0, 0, 96)],
+                     audioSegments=[aud(0, 0), aud(1, 360)]),
+                  duration_f=120, use_custom_audio=True, override_audio=True)
+check("Override Audio wins over the audio track", len(both_on["ref_audio_segs"]), 0)
+check_not_in("...so no <Audio N> is left declared", "<Audio 1>", both_on["prompt"])
+check_in("...and the clips that were not sent are named",
+         "clip: 'a0.wav', 'a1.wav'.", " ".join(both_on["ref_warnings"]))
+
+# No reference video means no soundtrack to be numbered first, so nothing can shift and the
+# clips are sent exactly as they are with Override Audio off.
+no_video = compile(tl([img(0, 120, "a.png", prompt="she walks")], ref_mode="ON",
+                      audioSegments=[aud(0, 0), aud(1, 360)]),
+                   duration_f=120, use_custom_audio=True, override_audio=True)
+check("Override Audio with no reference video keeps the clips",
+      [s["fileName"] for s in no_video["ref_audio_segs"]], ["a0.wav", "a1.wav"])
+
 # Ordering is still `start`, which is what numbers the labels — parked or not.
 reordered = compile(tl([img(0, 120, "a.png", prompt="she walks")], ref_mode="ON",
                        audioSegments=[aud(2, 720), aud(0, 0), aud(1, 360)]),

--- a/test_plan.py
+++ b/test_plan.py
@@ -1007,6 +1007,132 @@ check_in("a clip trimmed under 2s is reported, not silently extended",
                              motionSegments=[{"videoFile": "v.mp4", "fileName": "v.mp4",
                                               "start": 0, "length": 24}])
                           )["ref_warnings"]))
+
+# --------------------------- a reference does not have to spend output time
+# The model card wants each reference audio clip 10-15s long. H3's output is 4-15s. Three
+# clips laid end to end therefore cannot fit inside any window it can render, and while a
+# reference had to overlap the window you could have three references or a renderable
+# length, never both. <Video N> and <Audio N> are inputs to the model and are never
+# composited, so where the clip sits decides one thing only: whether an audio clip is
+# *also* part of the muxed soundtrack.
+def aud(i, start, length=360, **extra):
+    seg = {"audioFile": "a%d.wav" % i, "fileName": "a%d.wav" % i,
+           "start": start, "length": length, "audioDurationFrames": length, "trimStart": 0}
+    seg.update(extra)
+    return seg
+
+
+def vid(i, start, length=96, **extra):
+    seg = {"videoFile": "v%d.mp4" % i, "fileName": "v%d.mp4" % i,
+           "start": start, "length": length}
+    seg.update(extra)
+    return seg
+
+
+# three 15s clips end to end, in a 5s window: the issue's own case
+parked = compile(tl([img(0, 120, "a.png", prompt="she walks")], ref_mode="ON",
+                    audioSegments=[aud(i, i * 360) for i in range(3)]),
+                 duration_f=120, use_custom_audio=True)
+check("all three reference clips are sent from a 5s window",
+      len(parked["ref_audio_segs"]), 3)
+check("...and the output stays inside H3's trained range",
+      parked["length"] <= plan.TRAINED_MAX_FRAMES, True)
+for n in (1, 2, 3):
+    check_in("<Audio %d> is declared from past the window" % n,
+             "<Audio %d> is a reference audio clip: follow its voice and timbre." % n,
+             parked["prompt"])
+check_in("the task type counts them as references",
+         "audio reference", parked["prompt"])
+# Parking is now the ordinary way to hold a reference, so it must not be nagged about: a
+# warning that fires on every timeline of a kind is how a warnings area stops being read.
+# Which clips reach the soundtrack is said per clip, in the panel, where it is asked for.
+check("a parked clip is not warned about",
+      [w for w in parked["ref_warnings"] if "window" in w], [])
+
+# Override Audio is the exception, because there two explicit choices contradict each other:
+# it takes the soundtrack from the reference videos, and a parked clip cannot supply one.
+check_in("a parked clip that Override Audio was counting on is reported",
+         "Override Audio takes the soundtrack from the reference videos, and these sit past "
+         "the render window, so no part of them reaches combined_audio: 'v1.mp4'.",
+         " ".join(compile(tl([img(0, 120, "a.png", prompt="she walks")], ref_mode="ON",
+                             motionSegments=[vid(0, 0, 96), vid(1, 360, 96)]),
+                          duration_f=120, override_audio=True)["ref_warnings"]))
+check("...and says nothing when every clip is inside the window",
+      any("Override Audio takes" in w for w in
+          compile(tl([img(0, 120, "a.png", prompt="she walks")], ref_mode="ON",
+                     motionSegments=[vid(0, 0, 96)]),
+                  duration_f=120, override_audio=True)["ref_warnings"]), False)
+
+# Ordering is still `start`, which is what numbers the labels — parked or not.
+reordered = compile(tl([img(0, 120, "a.png", prompt="she walks")], ref_mode="ON",
+                       audioSegments=[aud(2, 720), aud(0, 0), aud(1, 360)]),
+                    duration_f=120, use_custom_audio=True)
+check("<Audio N> still follows the clip's position on the track",
+      [s["fileName"] for s in reordered["ref_audio_segs"]],
+      ["a0.wav", "a1.wav", "a2.wav"])
+
+# Reference video is the same shape, inside the 15s total budget the model card sets: three
+# 5s clips end to end need 15s of track, which no 5s output could ever have held.
+parked_vid = compile(tl([img(0, 120, "a.png", prompt="she walks")], ref_mode="ON",
+                        motionSegments=[vid(i, i * 120, 120) for i in range(3)]),
+                     duration_f=120)
+check("all three reference videos are sent from a 5s window",
+      len(parked_vid["ref_video_segs"]), 3)
+check_in("<Video 3> is declared from past the window", "<Video 3> is a reference video",
+         parked_vid["prompt"])
+# The model card's 15s total is about what the VAE is handed, not about where it sat, so
+# parking does not buy any more of it: three 6s clips still spend 12s and leave the third
+# nothing to fit in.
+budgeted = compile(tl([img(0, 120, "a.png", prompt="she walks")], ref_mode="ON",
+                      motionSegments=[vid(i, i * 144, 144) for i in range(3)]),
+                   duration_f=120)
+check("the 15s total budget still applies to parked clips",
+      [s["fileName"] for s in budgeted["ref_video_segs"]], ["v0.mp4", "v1.mp4"])
+check_in("...and still names what it dropped",
+         "Reference videos exceed the 15s total budget; 'v2.mp4' was dropped.",
+         " ".join(budgeted["ref_warnings"]))
+
+# Both per-type caps used to trim in silence. A fourth clip out in the shade looks exactly
+# as loaded as the three being sent, so it has to be named.
+capped_audio = compile(tl([img(0, 120, "a.png", prompt="she walks")], ref_mode="ON",
+                          audioSegments=[aud(i, i * 360) for i in range(4)]),
+                       duration_f=120, use_custom_audio=True)
+check("the fourth audio clip does not reach the model",
+      len(capped_audio["ref_audio_segs"]), plan.MAX_REF_AUDIOS)
+check_in("...and the cap names the clip it dropped",
+         "H3 takes at most 3 reference audio clips; 'a3.wav' was dropped.",
+         " ".join(capped_audio["ref_warnings"]))
+check_in("the video cap names its own casualty",
+         "H3 takes at most 3 reference video clips; 'v3.mp4' was dropped.",
+         " ".join(compile(tl([img(0, 120, "a.png", prompt="she walks")], ref_mode="ON",
+                             motionSegments=[vid(i, i * 120, 120) for i in range(4)]),
+                          duration_f=120)["ref_warnings"]))
+
+# Retake keeps the old rule. There the window is a deliberate sub-range of a video that
+# already exists, so outside it means "another part of this same video", not "parked" — and
+# the editor does not draw the audio track at all.
+retake_parked = plan.plan_timeline(
+    tl([img(0, 480, "a.png", prompt="she walks")], ref_mode="ON", retakeMode=True,
+       retakeVideo={"imageFile": "base.mp4", "videoDurationFrames": 480},
+       retakeStart=48, retakeLength=96,
+       audioSegments=[aud(0, 0, 96), aud(1, 360)]),
+    48, 96, FPS, use_custom_audio=True)
+check("a retake still ignores a clip outside the marked range",
+      [s["fileName"] for s in retake_parked["ref_audio_segs"]], ["a0.wav"])
+
+# Where the clip sits decides the soundtrack and nothing else, so it must not reach the
+# declaration: the same three clips inside the window compile to the same lines they do from
+# out in the shade. That is also what keeps every timeline written before this change intact.
+inside = compile(tl([img(0, 288, "a.png", prompt="she walks")], ref_mode="ON",
+                    audioSegments=[aud(i, 0, 96) for i in range(3)]),
+                 use_custom_audio=True)
+check("position changes nothing about what is declared",
+      [ln for ln in inside["prompt"].split("\n") if ln.startswith("<Audio")],
+      [ln for ln in parked["prompt"].split("\n") if ln.startswith("<Audio")])
+check("...nor the task type it earns",
+      plan.task_type_prefix([], [], inside["ref_audio_segs"]),
+      plan.task_type_prefix([], [], parked["ref_audio_segs"]))
+
 # ------------------------------------------- issue #10: whose voice is <Audio N>?
 two_chars = [{"images": [{"b64": "x", "name": "c1.png"}], "description": "a woman"},
              {"images": [{"b64": "x", "name": "c2.png"}], "description": "a man"}]


### PR DESCRIPTION
Closes #10 

- `<Audio j>` and `<Video k>` no longer have to overlap the window to be sent,
  so three 10-15s audio clips fit a 5s render instead of one
- neither reference track stretches duration_frames; only the main track
  decides how long the output is
- a parked reference video goes whole on its own trim rather than losing
  its head to a window start it has nothing to do with
- the per-type caps name the clip they drop, and Override Audio warns when
  the video it wants the soundtrack from is parked
- retake keeps the old rule: outside the marked range is another part of
  that same video

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
